### PR TITLE
Add basic narrative game skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.2",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1407,7 +1409,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1923,6 +1925,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1942,7 +1953,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2894,6 +2905,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3001,6 +3050,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3370,6 +3425,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.2",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,21 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import StartScreen from './screens/StartScreen'
+import PresentationScreen from './screens/PresentationScreen'
+import TurnScreen from './screens/TurnScreen'
+import ReactionScreen from './screens/ReactionScreen'
+import FinalScreen from './screens/FinalScreen'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<StartScreen />} />
+        <Route path="/presentation" element={<PresentationScreen />} />
+        <Route path="/turn" element={<TurnScreen />} />
+        <Route path="/reaction" element={<ReactionScreen />} />
+        <Route path="/final" element={<FinalScreen />} />
+      </Routes>
+    </BrowserRouter>
   )
 }
-
-export default App

--- a/src/screens/FinalScreen.tsx
+++ b/src/screens/FinalScreen.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom'
+
+export default function FinalScreen() {
+  return (
+    <div>
+      <h2>Thank you for playing!</h2>
+      <Link to="/">
+        <button>Back to Start</button>
+      </Link>
+    </div>
+  )
+}

--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom'
+import { useGameState } from '../state/gameState'
+
+export default function PresentationScreen() {
+  const { kingName, kingdom } = useGameState()
+  return (
+    <div>
+      <h2>Welcome to {kingdom}</h2>
+      <p>King {kingName} awaits your counsel.</p>
+      <Link to="/turn">
+        <button>Continue</button>
+      </Link>
+    </div>
+  )
+}

--- a/src/screens/ReactionScreen.tsx
+++ b/src/screens/ReactionScreen.tsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router-dom'
+import { useGameState } from '../state/gameState'
+
+export default function ReactionScreen() {
+  const { kingReaction } = useGameState()
+  return (
+    <div>
+      <p>{kingReaction}</p>
+      <Link to="/final">
+        <button>End Game</button>
+      </Link>
+    </div>
+  )
+}

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom'
+
+export default function StartScreen() {
+  return (
+    <div>
+      <h1>The Advisor</h1>
+      <Link to="/presentation">
+        <button>Start Game</button>
+      </Link>
+    </div>
+  )
+}

--- a/src/screens/TurnScreen.tsx
+++ b/src/screens/TurnScreen.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useGameState } from '../state/gameState'
+
+export default function TurnScreen() {
+  const { setPlayerAdvice } = useGameState()
+  const [advice, setAdvice] = useState('')
+
+  const handleSend = () => {
+    setPlayerAdvice(advice)
+  }
+
+  return (
+    <div>
+      <p>Villagers have gathered in the square with torches.</p>
+      <p>Should we intervene or let them speak freely?</p>
+      <input
+        value={advice}
+        onChange={(e) => setAdvice(e.target.value)}
+        placeholder="Your advice"
+      />
+      <Link to="/reaction">
+        <button onClick={handleSend}>Send Advice</button>
+      </Link>
+    </div>
+  )
+}

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+export interface GameState {
+  kingName: string
+  kingdom: string
+  playerAdvice: string
+  kingReaction: string
+  setKingName: (name: string) => void
+  setKingdom: (kingdom: string) => void
+  setPlayerAdvice: (advice: string) => void
+  setKingReaction: (reaction: string) => void
+}
+
+export const useGameState = create<GameState>((set) => ({
+  kingName: 'Aldric the Just',
+  kingdom: 'Eldoria',
+  playerAdvice: '',
+  kingReaction: 'The King nods solemnly, but his gaze is stern.',
+  setKingName: (kingName) => set({ kingName }),
+  setKingdom: (kingdom) => set({ kingdom }),
+  setPlayerAdvice: (playerAdvice) => set({ playerAdvice }),
+  setKingReaction: (kingReaction) => set({ kingReaction }),
+}))


### PR DESCRIPTION
## Summary
- install `react-router-dom` and `zustand`
- create simple screen components for the game flow
- wire up routing in `App.tsx`
- manage game data with a Zustand store

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849952946448328bfdddaafe24a0775