### PR TITLE
Add mock content and state logic to screens

### DIFF
--- a/src/screens/FinalScreen.tsx
+++ b/src/screens/FinalScreen.tsx
@@ -1,12 +1,23 @@
-import { Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+import { useGameState } from '../state/gameState'
 
 export default function FinalScreen() {
+  const navigate = useNavigate()
+  const { setKingName, setKingdom, setPlayerAdvice, setKingReaction } =
+    useGameState()
+
+  const handleReset = () => {
+    setKingName('')
+    setKingdom('')
+    setPlayerAdvice('')
+    setKingReaction('')
+    navigate('/')
+  }
+
   return (
     <div>
-      <h2>Thank you for playing!</h2>
-      <Link to="/">
-        <button>Back to Start</button>
-      </Link>
+      <p>Your service has ended. The future of Eldoria is uncertain.</p>
+      <button onClick={handleReset}>Play Again</button>
     </div>
   )
 }

--- a/src/screens/PresentationScreen.tsx
+++ b/src/screens/PresentationScreen.tsx
@@ -5,8 +5,8 @@ export default function PresentationScreen() {
   const { kingName, kingdom } = useGameState()
   return (
     <div>
-      <h2>Welcome to {kingdom}</h2>
-      <p>King {kingName} awaits your counsel.</p>
+      <h2>{kingName} of {kingdom}</h2>
+      <p>You are now the advisor of King {kingName} of {kingdom}.</p>
       <Link to="/turn">
         <button>Continue</button>
       </Link>

--- a/src/screens/ReactionScreen.tsx
+++ b/src/screens/ReactionScreen.tsx
@@ -1,10 +1,17 @@
 import { Link } from 'react-router-dom'
+import { useEffect } from 'react'
 import { useGameState } from '../state/gameState'
 
 export default function ReactionScreen() {
-  const { kingReaction } = useGameState()
+  const { kingName, playerAdvice, kingReaction, setKingReaction } = useGameState()
+
+  useEffect(() => {
+    setKingReaction('The King nods solemnly, but his gaze is stern.')
+  }, [setKingReaction])
+
   return (
     <div>
+      <p>Your advice to King {kingName}: {playerAdvice}</p>
       <p>{kingReaction}</p>
       <Link to="/final">
         <button>End Game</button>

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -1,12 +1,20 @@
-import { Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+import { useGameState } from '../state/gameState'
 
 export default function StartScreen() {
+  const navigate = useNavigate()
+  const { setKingName, setKingdom } = useGameState()
+
+  const handleStart = () => {
+    setKingName('Aldric the Just')
+    setKingdom('Eldoria')
+    navigate('/presentation')
+  }
+
   return (
     <div>
       <h1>The Advisor</h1>
-      <Link to="/presentation">
-        <button>Start Game</button>
-      </Link>
+      <button onClick={handleStart}>Start Game</button>
     </div>
   )
 }

--- a/src/screens/TurnScreen.tsx
+++ b/src/screens/TurnScreen.tsx
@@ -12,9 +12,9 @@ export default function TurnScreen() {
 
   return (
     <div>
-      <p>Villagers have gathered in the square with torches.</p>
+      <p>The villagers have gathered in the square with torches.</p>
       <p>Should we intervene or let them speak freely?</p>
-      <input
+      <textarea
         value={advice}
         onChange={(e) => setAdvice(e.target.value)}
         placeholder="Your advice"


### PR DESCRIPTION
## Summary
- implement mock flows for Start, Presentation, Turn, Reaction and Final screens
- wire screens with Zustand global state
- add advice textarea and reaction logic

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684997c803848328b619936e567236d8