### PR TITLE
Implement basic Advisor game flow

### DIFF
--- a/src/screens/FinalScreen.tsx
+++ b/src/screens/FinalScreen.tsx
@@ -3,14 +3,10 @@ import { useGameState } from '../state/gameState'
 
 export default function FinalScreen() {
   const navigate = useNavigate()
-  const { setKingName, setKingdom, setPlayerAdvice, setKingReaction } =
-    useGameState()
+  const { resetState } = useGameState()
 
   const handleReset = () => {
-    setKingName('')
-    setKingdom('')
-    setPlayerAdvice('')
-    setKingReaction('')
+    resetState()
     navigate('/')
   }
 

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -9,15 +9,17 @@ export interface GameState {
   setKingdom: (kingdom: string) => void
   setPlayerAdvice: (advice: string) => void
   setKingReaction: (reaction: string) => void
+  resetState: () => void
 }
 
 export const useGameState = create<GameState>((set) => ({
-  kingName: 'Aldric the Just',
-  kingdom: 'Eldoria',
+  kingName: '',
+  kingdom: '',
   playerAdvice: '',
-  kingReaction: 'The King nods solemnly, but his gaze is stern.',
+  kingReaction: '',
   setKingName: (kingName) => set({ kingName }),
   setKingdom: (kingdom) => set({ kingdom }),
   setPlayerAdvice: (playerAdvice) => set({ playerAdvice }),
   setKingReaction: (kingReaction) => set({ kingReaction }),
+  resetState: () => set({ kingName: '', kingdom: '', playerAdvice: '', kingReaction: '' }),
 }))


### PR DESCRIPTION
## Summary
- add a resettable zustand store for the game state
- call `resetState` in FinalScreen to restart the game

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684999cefc788328a0766ccd023b701f