### PR TITLE
Add level selection screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import StartScreen from './screens/StartScreen'
+import LevelSelectionScreen from './screens/LevelSelectionScreen'
 import PresentationScreen from './screens/PresentationScreen'
 import TurnScreen from './screens/TurnScreen'
 import ReactionScreen from './screens/ReactionScreen'
@@ -11,6 +12,7 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<StartScreen />} />
+        <Route path="/level" element={<LevelSelectionScreen />} />
         <Route path="/presentation" element={<PresentationScreen />} />
         <Route path="/turn" element={<TurnScreen />} />
         <Route path="/reaction" element={<ReactionScreen />} />

--- a/src/screens/LevelSelectionScreen.tsx
+++ b/src/screens/LevelSelectionScreen.tsx
@@ -1,0 +1,33 @@
+import { useNavigate } from 'react-router-dom'
+import { useGameState } from '../state/gameState'
+
+const levels = [
+  'Aldea',
+  'Gobernador',
+  'Corte Real',
+  'Reino Mitológico',
+  'Oráculo Legendario',
+]
+
+export default function LevelSelectionScreen() {
+  const navigate = useNavigate()
+  const { setLevel } = useGameState()
+
+  const handleSelect = (level: string) => {
+    setLevel(level)
+    navigate('/presentation')
+  }
+
+  return (
+    <div>
+      <h2>Select your level of influence</h2>
+      <ul>
+        {levels.map((level) => (
+          <li key={level}>
+            <button onClick={() => handleSelect(level)}>{level}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -8,7 +8,7 @@ export default function StartScreen() {
   const handleStart = () => {
     setKingName('Aldric the Just')
     setKingdom('Eldoria')
-    navigate('/presentation')
+    navigate('/level')
   }
 
   return (

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -5,10 +5,12 @@ export interface GameState {
   kingdom: string
   playerAdvice: string
   kingReaction: string
+  level: string
   setKingName: (name: string) => void
   setKingdom: (kingdom: string) => void
   setPlayerAdvice: (advice: string) => void
   setKingReaction: (reaction: string) => void
+  setLevel: (level: string) => void
   resetState: () => void
 }
 
@@ -17,9 +19,11 @@ export const useGameState = create<GameState>((set) => ({
   kingdom: '',
   playerAdvice: '',
   kingReaction: '',
+  level: '',
   setKingName: (kingName) => set({ kingName }),
   setKingdom: (kingdom) => set({ kingdom }),
   setPlayerAdvice: (playerAdvice) => set({ playerAdvice }),
   setKingReaction: (kingReaction) => set({ kingReaction }),
-  resetState: () => set({ kingName: '', kingdom: '', playerAdvice: '', kingReaction: '' }),
+  setLevel: (level) => set({ level }),
+  resetState: () => set({ kingName: '', kingdom: '', playerAdvice: '', kingReaction: '', level: '' }),
 }))


### PR DESCRIPTION
## Summary
- add a LevelSelectionScreen with options for influence level
- store the selected level in Zustand game state
- route new screen at `/level`
- start game at level selection screen

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68499e428a788328af9c2c235174c36a