### PR TITLE
Extend game state with narrative plot

### DIFF
--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -1,16 +1,41 @@
 import { create } from 'zustand'
 
+export interface Plot {
+  id: string
+  inspirationalPhrase: string
+  tone: 'light' | 'dark' | 'neutral'
+  difficulty: 'easy' | 'medium' | 'hard'
+  level:
+    | 'village'
+    | 'governor'
+    | 'royal_court'
+    | 'mythical_kingdom'
+    | 'legendary_oracle'
+  startingState: Record<string, unknown>
+  requiredEvents: string[]
+  optionalTwists: string[]
+  revealTiming: {
+    hint: number
+    conflict: number
+    climax: number
+  }
+  tags: string[]
+}
+
 export interface GameState {
   kingName: string
   kingdom: string
   playerAdvice: string
   kingReaction: string
   level: string
+  mainPlot: Plot | null
   setKingName: (name: string) => void
   setKingdom: (kingdom: string) => void
   setPlayerAdvice: (advice: string) => void
   setKingReaction: (reaction: string) => void
   setLevel: (level: string) => void
+  setMainPlot: (plot: Plot) => void
+  resetMainPlot: () => void
   resetState: () => void
 }
 
@@ -20,10 +45,13 @@ export const useGameState = create<GameState>((set) => ({
   playerAdvice: '',
   kingReaction: '',
   level: '',
+  mainPlot: null,
   setKingName: (kingName) => set({ kingName }),
   setKingdom: (kingdom) => set({ kingdom }),
   setPlayerAdvice: (playerAdvice) => set({ playerAdvice }),
   setKingReaction: (kingReaction) => set({ kingReaction }),
   setLevel: (level) => set({ level }),
+  setMainPlot: (mainPlot) => set({ mainPlot }),
+  resetMainPlot: () => set({ mainPlot: null }),
   resetState: () => set({ kingName: '', kingdom: '', playerAdvice: '', kingReaction: '', level: '' }),
 }))


### PR DESCRIPTION
## Summary
- create `Plot` interface for main story details
- track `mainPlot` in Zustand store with setters and resetter

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849a46f1058832888361c0922a50581