### PR TITLE
Add initial plot generator

### DIFF
--- a/src/lib/narrative.ts
+++ b/src/lib/narrative.ts
@@ -1,0 +1,31 @@
+import { callAssistant } from './openai'
+import { useGameState } from '../state/gameState'
+
+export async function generateInitialPlot(): Promise<void> {
+  const prompt = `Generate a JSON object representing a narrative plot for a medieval advisor game.
+The plot must follow this strict structure:
+{
+  id: string,
+  inspirationalPhrase: string,
+  tone: 'light' | 'dark' | 'neutral',
+  difficulty: 'easy' | 'medium' | 'hard',
+  level: 'village' | 'governor' | 'royal_court' | 'mythical_kingdom' | 'legendary_oracle',
+  startingState: Record<string, unknown>,
+  requiredEvents: string[],
+  optionalTwists: string[],
+  revealTiming: { hint: number, conflict: number, climax: number },
+  tags: string[]
+}
+Do not explain or wrap the output. Return only valid JSON.`
+  try {
+    const result = await callAssistant(
+      'asst_xBvJOGRlyLWAJlQeWWTLFw8q',
+      prompt,
+    )
+    if (!result) throw new Error('No response from OpenAI')
+    const plot = JSON.parse(result)
+    useGameState.getState().setMainPlot(plot)
+  } catch (error) {
+    console.error('Failed to generate initial plot', error)
+  }
+}


### PR DESCRIPTION
## Summary
- implement `generateInitialPlot` helper for creating a plot with OpenAI
- save returned plot in Zustand state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849abc074d08328ae66ab3118a2ba7d