### PR TITLE
Fetch plot on presentation

### DIFF
--- a/src/lib/narrative.ts
+++ b/src/lib/narrative.ts
@@ -1,7 +1,8 @@
 import { callAssistant } from './openai'
-import { useGameState } from '../state/gameState'
 
-export async function generateInitialPlot(): Promise<void> {
+import type { Plot } from '../state/gameState'
+
+export async function generateInitialPlot(): Promise<Plot | null> {
   const prompt = `Generate a JSON object representing a narrative plot for a medieval advisor game.
 The plot must follow this strict structure:
 {
@@ -23,9 +24,10 @@ Do not explain or wrap the output. Return only valid JSON.`
       prompt,
     )
     if (!result) throw new Error('No response from OpenAI')
-    const plot = JSON.parse(result)
-    useGameState.getState().setMainPlot(plot)
+    const plot: Plot = JSON.parse(result)
+    return plot
   } catch (error) {
     console.error('Failed to generate initial plot', error)
+    return null
   }
 }

--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -1,10 +1,41 @@
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
+import { generateInitialPlot } from '../../lib/narrative'
 import ViewPresentationScreen from '../view/ViewPresentationScreen'
 
 export default function PresentationScreen() {
-  const { kingName, kingdom } = useGameState()
+  const {
+    kingName,
+    kingdom,
+    setKingName,
+    setKingdom,
+    setMainPlot,
+  } = useGameState()
   const navigate = useNavigate()
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const plot = await generateInitialPlot()
+        console.log('Generated plot:', plot)
+        if (plot) {
+          setMainPlot(plot)
+          setKingName(plot.id || 'Aldric')
+          const firstTag = plot.tags && plot.tags.length > 0 ? plot.tags[0] : ''
+          setKingdom(firstTag || 'Eldoria')
+        } else {
+          setKingName('Aldric')
+          setKingdom('Eldoria')
+        }
+      } catch (error) {
+        console.error('Error initializing plot', error)
+        setKingName('Aldric')
+        setKingdom('Eldoria')
+      }
+    }
+    init()
+  }, [setKingName, setKingdom, setMainPlot])
 
   const handleContinue = () => {
     navigate('/turn')


### PR DESCRIPTION
## Summary
- return plot from `generateInitialPlot`
- load plot in `PresentationScreen` and store king/kingdom
- show generated plot in console

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849aff119688328b6248f6a77ef39c4