### PR TITLE
Add API key logging for debug

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -4,6 +4,8 @@ export async function callAssistant(
   threadId?: string,
 ): Promise<string> {
   const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+  // Temporary log to verify env variable is loaded correctly
+  console.log('Loaded API key:', apiKey?.slice(0, 5))
   if (!apiKey) {
     throw new Error('OpenAI API key is missing')
   }


### PR DESCRIPTION
## Summary
- temporarily log the first 5 characters of the OpenAI API key to verify env loading

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849b2c8d8448328adff0fc656437a06