### PR TITLE
Add debug info to Presentation screen

### DIFF
--- a/src/lib/narrative.ts
+++ b/src/lib/narrative.ts
@@ -2,8 +2,7 @@ import { callAssistant } from './openai'
 
 import type { Plot } from '../state/gameState'
 
-export async function generateInitialPlot(): Promise<Plot | null> {
-  const prompt = `Generate a JSON object representing a narrative plot for a medieval advisor game.
+export const initialPlotPrompt = `Generate a JSON object representing a narrative plot for a medieval advisor game.
 The plot must follow this strict structure:
 {
   id: string,
@@ -18,6 +17,9 @@ The plot must follow this strict structure:
   tags: string[]
 }
 Do not explain or wrap the output. Return only valid JSON.`
+
+export async function generateInitialPlot(): Promise<Plot | null> {
+  const prompt = initialPlotPrompt
   try {
     const result = await callAssistant(
       'asst_xBvJOGRlyLWAJlQeWWTLFw8q',

--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
-import { generateInitialPlot } from '../../lib/narrative'
+import { generateInitialPlot, initialPlotPrompt } from '../../lib/narrative'
 import ViewPresentationScreen from '../view/ViewPresentationScreen'
 
 export default function PresentationScreen() {
@@ -13,11 +13,14 @@ export default function PresentationScreen() {
     setMainPlot,
   } = useGameState()
   const navigate = useNavigate()
+  const [debugText, setDebugText] = useState('')
 
   useEffect(() => {
     const init = async () => {
       try {
+        setDebugText(`Prompt:\n${initialPlotPrompt}\n\n`)
         const plot = await generateInitialPlot()
+        setDebugText((prev) => prev + `Raw result:\n${JSON.stringify(plot, null, 2)}\n`)
         console.log('Generated plot:', plot)
         if (plot) {
           setMainPlot(plot)
@@ -27,11 +30,13 @@ export default function PresentationScreen() {
         } else {
           setKingName('Aldric')
           setKingdom('Eldoria')
+          setDebugText((prev) => prev + 'Fallback: plot was null\n')
         }
       } catch (error) {
         console.error('Error initializing plot', error)
         setKingName('Aldric')
         setKingdom('Eldoria')
+        setDebugText((prev) => prev + `Error: ${(error as Error).message}\n`)
       }
     }
     init()
@@ -46,6 +51,7 @@ export default function PresentationScreen() {
       kingName={kingName}
       kingdom={kingdom}
       onContinue={handleContinue}
+      debugText={debugText}
     />
   )
 }

--- a/src/screens/view/ViewPresentationScreen.tsx
+++ b/src/screens/view/ViewPresentationScreen.tsx
@@ -2,14 +2,26 @@ interface ViewPresentationScreenProps {
   kingName: string
   kingdom: string
   onContinue: () => void
+  debugText: string
 }
 
-export default function ViewPresentationScreen({ kingName, kingdom, onContinue }: ViewPresentationScreenProps) {
+export default function ViewPresentationScreen({ kingName, kingdom, onContinue, debugText }: ViewPresentationScreenProps) {
   return (
     <div>
       <h2>{kingName} of {kingdom}</h2>
       <p>You are now the advisor of King {kingName} of {kingdom}.</p>
       <button onClick={onContinue}>Continue</button>
+      <details style={{ marginTop: '1rem' }}>
+        <summary>Debug</summary>
+        <pre style={{
+          background: '#333',
+          color: '#eee',
+          fontSize: '0.75rem',
+          overflow: 'auto',
+          padding: '0.5rem',
+          whiteSpace: 'pre-wrap',
+        }}>{debugText}</pre>
+      </details>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- export `initialPlotPrompt` and reuse in `PresentationScreen`
- keep a debug log during GPT plot generation
- expose debug text in `ViewPresentationScreen`
- show collapsible debug panel with styling

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849b2cede248328b35d4404d18e8f4e