### PR TITLE
Add king loader

### DIFF
--- a/src/data/kings.json
+++ b/src/data/kings.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "king_aldric_justo",
+    "name": "Aldric",
+    "epithet": "the Just",
+    "personality": "strict but fair",
+    "king_phrase": "Justice must never waver.",
+    "general_tone": "solemn and balanced",
+    "kingdom_context": "The kingdom is recovering from a long civil war and stability is fragile.",
+    "throne_room_description": "The royal hall is austere, flanked by cold stone columns and a high vaulted ceiling.",
+    "tags": ["law", "balance", "recovery"],
+    "visual": "king_throne_dark01"
+  },
+  {
+    "id": "king_lauren_cunning",
+    "name": "Lauren",
+    "epithet": "the Cunning",
+    "personality": "clever and manipulative",
+    "king_phrase": "Knowledge is power.",
+    "general_tone": "scheming and mischievous",
+    "kingdom_context": "The realm thrives on trade and hidden alliances.",
+    "throne_room_description": "Bright banners cover the walls, but whispers fill the court.",
+    "tags": ["trade", "alliances", "intrigue"],
+    "visual": "king_throne_light02"
+  }
+]

--- a/src/lib/kings.ts
+++ b/src/lib/kings.ts
@@ -1,0 +1,7 @@
+import kings from '../data/kings.json'
+import type { King } from '../types'
+
+export function getRandomKing(): King {
+  const index = Math.floor(Math.random() * kings.length)
+  return kings[index] as King
+}

--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import { generateInitialPlot, initialPlotPrompt } from '../../lib/narrative'
+import { getRandomKing } from '../../lib/kings'
 import ViewPresentationScreen from '../view/ViewPresentationScreen'
 
 export default function PresentationScreen() {
@@ -11,6 +12,7 @@ export default function PresentationScreen() {
     setKingName,
     setKingdom,
     setMainPlot,
+    setCurrentKing,
   } = useGameState()
   const navigate = useNavigate()
   const [debugText, setDebugText] = useState('')
@@ -18,29 +20,28 @@ export default function PresentationScreen() {
   useEffect(() => {
     const init = async () => {
       try {
+        const king = getRandomKing()
+        setCurrentKing(king)
+        setKingName(`${king.name} ${king.epithet}`)
+        if (king.tags && king.tags.length > 0) {
+          setKingdom(king.tags[0])
+        }
         setDebugText(`Prompt:\n${initialPlotPrompt}\n\n`)
         const plot = await generateInitialPlot()
         setDebugText((prev) => prev + `Raw result:\n${JSON.stringify(plot, null, 2)}\n`)
         console.log('Generated plot:', plot)
         if (plot) {
           setMainPlot(plot)
-          setKingName(plot.id || 'Aldric')
-          const firstTag = plot.tags && plot.tags.length > 0 ? plot.tags[0] : ''
-          setKingdom(firstTag || 'Eldoria')
         } else {
-          setKingName('Aldric')
-          setKingdom('Eldoria')
           setDebugText((prev) => prev + 'Fallback: plot was null\n')
         }
       } catch (error) {
         console.error('Error initializing plot', error)
-        setKingName('Aldric')
-        setKingdom('Eldoria')
         setDebugText((prev) => prev + `Error: ${(error as Error).message}\n`)
       }
     }
     init()
-  }, [setKingName, setKingdom, setMainPlot])
+  }, [setKingName, setKingdom, setMainPlot, setCurrentKing])
 
   const handleContinue = () => {
     navigate('/turn')

--- a/src/screens/view/ViewPresentationScreen.tsx
+++ b/src/screens/view/ViewPresentationScreen.tsx
@@ -1,3 +1,5 @@
+import { useGameState } from '../../state/gameState'
+
 interface ViewPresentationScreenProps {
   kingName: string
   kingdom: string
@@ -6,9 +8,14 @@ interface ViewPresentationScreenProps {
 }
 
 export default function ViewPresentationScreen({ kingName, kingdom, onContinue, debugText }: ViewPresentationScreenProps) {
+  const { currentKing } = useGameState()
+  const phrase = currentKing?.king_phrase || 'Long live the king.'
+  const throneDesc = currentKing?.throne_room_description || 'The throne room awaits.'
   return (
     <div>
       <h2>{kingName} of {kingdom}</h2>
+      <p>{phrase}</p>
+      <p>{throneDesc}</p>
       <p>You are now the advisor of King {kingName} of {kingdom}.</p>
       <button onClick={onContinue}>Continue</button>
       <details style={{ marginTop: '1rem' }}>

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import type { King } from '../types'
 
 export interface Plot {
   id: string
@@ -29,12 +30,14 @@ export interface GameState {
   kingReaction: string
   level: string
   mainPlot: Plot | null
+  currentKing: King | null
   setKingName: (name: string) => void
   setKingdom: (kingdom: string) => void
   setPlayerAdvice: (advice: string) => void
   setKingReaction: (reaction: string) => void
   setLevel: (level: string) => void
   setMainPlot: (plot: Plot) => void
+  setCurrentKing: (king: King) => void
   resetMainPlot: () => void
   resetState: () => void
 }
@@ -46,12 +49,15 @@ export const useGameState = create<GameState>((set) => ({
   kingReaction: '',
   level: '',
   mainPlot: null,
+  currentKing: null,
   setKingName: (kingName) => set({ kingName }),
   setKingdom: (kingdom) => set({ kingdom }),
   setPlayerAdvice: (playerAdvice) => set({ playerAdvice }),
   setKingReaction: (kingReaction) => set({ kingReaction }),
   setLevel: (level) => set({ level }),
   setMainPlot: (mainPlot) => set({ mainPlot }),
+  setCurrentKing: (currentKing) => set({ currentKing }),
   resetMainPlot: () => set({ mainPlot: null }),
-  resetState: () => set({ kingName: '', kingdom: '', playerAdvice: '', kingReaction: '', level: '' }),
+  resetState: () =>
+    set({ kingName: '', kingdom: '', playerAdvice: '', kingReaction: '', level: '', currentKing: null }),
 }))

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+export interface King {
+  id: string
+  name: string
+  epithet: string
+  personality: string
+  king_phrase: string
+  general_tone: string
+  kingdom_context: string
+  throne_room_description: string
+  tags: string[]
+  visual?: string
+}


### PR DESCRIPTION
## Summary
- add random king data in `kings.json`
- define `King` interface
- create `getRandomKing` helper
- track king in game state
- display king info during presentation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849b61bf4dc8328b42b515c22570b63