### PR TITLE
Add plot-based king selector

### DIFF
--- a/src/lib/kingSelector.ts
+++ b/src/lib/kingSelector.ts
@@ -1,0 +1,17 @@
+import kings from '../data/kings.json'
+import type { Plot } from '../state/gameState'
+
+export function findMatchingKing(plot: Plot) {
+  let bestMatch = null
+  let maxMatches = 0
+
+  for (const king of kings) {
+    const matches = king.tags.filter(tag => plot.tags.includes(tag)).length
+    if (matches > maxMatches) {
+      bestMatch = king
+      maxMatches = matches
+    }
+  }
+
+  return bestMatch
+}

--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import { generateInitialPlot, initialPlotPrompt } from '../../lib/narrative'
-import { getRandomKing } from '../../lib/kings'
+import { findMatchingKing } from '../../lib/kingSelector'
 import ViewPresentationScreen from '../view/ViewPresentationScreen'
 
 export default function PresentationScreen() {
@@ -20,18 +20,19 @@ export default function PresentationScreen() {
   useEffect(() => {
     const init = async () => {
       try {
-        const king = getRandomKing()
-        setCurrentKing(king)
-        setKingName(`${king.name} ${king.epithet}`)
-        if (king.tags && king.tags.length > 0) {
-          setKingdom(king.tags[0])
-        }
         setDebugText(`Prompt:\n${initialPlotPrompt}\n\n`)
         const plot = await generateInitialPlot()
         setDebugText((prev) => prev + `Raw result:\n${JSON.stringify(plot, null, 2)}\n`)
         console.log('Generated plot:', plot)
         if (plot) {
           setMainPlot(plot)
+          const king = findMatchingKing(plot)
+          console.log('Selected king:', king)
+          if (king) {
+            setCurrentKing(king)
+            setKingName(`${king.name} ${king.epithet}`)
+          }
+          setKingdom(plot.tags[0] || 'Eldoria')
         } else {
           setDebugText((prev) => prev + 'Fallback: plot was null\n')
         }


### PR DESCRIPTION
## Summary
- create helper `findMatchingKing` to choose the best king for a plot
- use this helper when presenting the game so that the selected king matches plot tags
- output debug info with the chosen king

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849ba4849bc83288b6713c031abb30c