### PR TITLE
Add debug details for king/plot in ViewPresentationScreen

### DIFF
--- a/src/screens/view/ViewPresentationScreen.tsx
+++ b/src/screens/view/ViewPresentationScreen.tsx
@@ -8,7 +8,7 @@ interface ViewPresentationScreenProps {
 }
 
 export default function ViewPresentationScreen({ kingName, kingdom, onContinue, debugText }: ViewPresentationScreenProps) {
-  const { currentKing } = useGameState()
+  const { currentKing, mainPlot } = useGameState()
   const phrase = currentKing?.king_phrase || 'Long live the king.'
   const throneDesc = currentKing?.throne_room_description || 'The throne room awaits.'
   return (
@@ -28,6 +28,14 @@ export default function ViewPresentationScreen({ kingName, kingdom, onContinue, 
           padding: '0.5rem',
           whiteSpace: 'pre-wrap',
         }}>{debugText}</pre>
+        {currentKing && mainPlot && (
+          <div style={{ marginTop: '1rem' }}>
+            <h4>🧪 Test visual de asignación</h4>
+            <p><strong>Rey:</strong> {currentKing.name} ({currentKing.epithet})</p>
+            <p><strong>Tags del Rey:</strong> {currentKing.tags.join(', ')}</p>
+            <p><strong>Tags de la Trama:</strong> {mainPlot.tags.join(', ')}</p>
+          </div>
+        )}
       </details>
     </div>
   )


### PR DESCRIPTION
## Summary
- show mainPlot debug info in ViewPresentationScreen

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849bb8a77008328a9851c85360dfd59