### PR TITLE
Reuse existing plot in presentation screen

### DIFF
--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -9,6 +9,7 @@ export default function PresentationScreen() {
   const {
     kingName,
     kingdom,
+    mainPlot,
     setKingName,
     setKingdom,
     setMainPlot,
@@ -20,21 +21,28 @@ export default function PresentationScreen() {
   useEffect(() => {
     const init = async () => {
       try {
-        setDebugText(`Prompt:\n${initialPlotPrompt}\n\n`)
-        const plot = await generateInitialPlot()
-        setDebugText((prev) => prev + `Raw result:\n${JSON.stringify(plot, null, 2)}\n`)
-        console.log('Generated plot:', plot)
-        if (plot) {
-          setMainPlot(plot)
-          const king = findMatchingKing(plot)
+        if (mainPlot) {
+          const king = findMatchingKing(mainPlot)
+          console.log('Using existing plot:', mainPlot)
           console.log('Selected king:', king)
-          if (king) {
-            setCurrentKing(king)
-            setKingName(`${king.name} ${king.epithet}`)
-          }
-          setKingdom(plot.tags[0] || 'Eldoria')
+          setCurrentKing(king)
+          setKingName(`${king?.name} ${king?.epithet}`)
+          setKingdom(mainPlot.tags[0] || 'Eldoria')
         } else {
-          setDebugText((prev) => prev + 'Fallback: plot was null\n')
+          setDebugText(`Prompt:\n${initialPlotPrompt}\n\n`)
+          const plot = await generateInitialPlot()
+          setDebugText((prev) => prev + `Raw result:\n${JSON.stringify(plot, null, 2)}\n`)
+          console.log('Generated plot:', plot)
+          if (plot) {
+            setMainPlot(plot)
+            const king = findMatchingKing(plot)
+            console.log('Selected king:', king)
+            setCurrentKing(king)
+            setKingName(`${king?.name} ${king?.epithet}`)
+            setKingdom(plot.tags[0] || 'Eldoria')
+          } else {
+            setDebugText((prev) => prev + 'Fallback: plot was null\n')
+          }
         }
       } catch (error) {
         console.error('Error initializing plot', error)
@@ -42,7 +50,7 @@ export default function PresentationScreen() {
       }
     }
     init()
-  }, [setKingName, setKingdom, setMainPlot, setCurrentKing])
+  }, [mainPlot, setKingName, setKingdom, setMainPlot, setCurrentKing])
 
   const handleContinue = () => {
     navigate('/turn')


### PR DESCRIPTION
## Summary
- avoid extra GPT calls by checking if `mainPlot` already exists in the game state
- if present, choose the king from it instead of generating a new plot

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849d113143c8328b10861972c763512