### PR TITLE
Implement narrative mutation system

### DIFF
--- a/src/data/mutationsPlot.json
+++ b/src/data/mutationsPlot.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "mutation_royal_reform_success",
+    "title": "Winds of Reform",
+    "description": "The King announces a wave of reforms inspired by the Counselor's guidance.",
+    "effects": {
+      "prestige": 10,
+      "trust": 15,
+      "war": false
+    },
+    "requiredTags": ["reform", "balance"],
+    "forbiddenTags": ["war", "betrayal"],
+    "minTurns": 3,
+    "linkedEvents": ["reform_tax_system", "heal_faction_conflict"],
+    "unlockCards": ["card_reformist_push"],
+    "triggeredRumors": ["rumor_reform_wave"],
+    "visual": {
+      "tag_ia": "king in white robes addressing the court with open scrolls and sunlight"
+    }
+  },
+  {
+    "id": "mutation_blood_in_council",
+    "title": "Blood in the Council",
+    "description": "A noble is found murdered. Panic and suspicion spread across the court.",
+    "effects": {
+      "prestige": -15,
+      "trust": -10,
+      "war": false
+    },
+    "requiredTags": ["intrigue", "power"],
+    "forbiddenTags": ["peace", "stability"],
+    "minTurns": 4,
+    "linkedEvents": ["expose_traitor"],
+    "unlockCards": ["card_interrogate"],
+    "triggeredRumors": ["rumor_murder_in_court"],
+    "visual": {
+      "tag_ia": "bloodstained council table in a dark medieval room"
+    }
+  },
+  {
+    "id": "mutation_silent_rebellion",
+    "title": "The Silent Rebellion",
+    "description": "Peasants begin to withhold taxes in a quiet, coordinated resistance.",
+    "effects": {
+      "prestige": -5,
+      "trust": -5,
+      "war": false
+    },
+    "requiredTags": ["dissent", "economy"],
+    "forbiddenTags": ["prosperity"],
+    "minTurns": 5,
+    "linkedEvents": ["restructure_trade_routes"],
+    "unlockCards": ["card_peasant_decree"],
+    "triggeredRumors": ["rumor_tax_resistance"],
+    "visual": {
+      "tag_ia": "angry villagers holding back wheat and coins from royal collectors"
+    }
+  }
+]

--- a/src/lib/mutationLogic.ts
+++ b/src/lib/mutationLogic.ts
@@ -1,0 +1,58 @@
+import mutationsData from '../data/mutationsPlot.json'
+import type { Plot } from '../state/gameState'
+import { useGameState } from '../state/gameState'
+
+export interface Mutation {
+  id: string
+  title: string
+  description: string
+  effects: {
+    prestige?: number
+    trust?: number
+    war?: boolean
+  }
+  requiredTags: string[]
+  forbiddenTags: string[]
+  minTurns: number
+  linkedEvents: string[]
+  unlockCards: string[]
+  triggeredRumors: string[]
+  visual?: { tag_ia: string }
+}
+
+const mutations = mutationsData as Mutation[]
+
+export function checkAndTriggerMutations(
+  currentTurn: number,
+  mainPlot: Plot | null,
+  gameState: ReturnType<typeof useGameState.getState>,
+): Mutation[] {
+  if (!mainPlot) return []
+
+  const triggered: Mutation[] = []
+
+  for (const m of mutations) {
+    if (gameState.activatedMutations.includes(m.id)) continue
+    if (currentTurn < m.minTurns) continue
+    if (!m.requiredTags.every((t) => mainPlot.tags.includes(t))) continue
+    if (m.forbiddenTags.some((t) => mainPlot.tags.includes(t))) continue
+
+    if (typeof m.effects.prestige === 'number') {
+      gameState.setPrestige(gameState.prestige + m.effects.prestige)
+    }
+    if (typeof m.effects.trust === 'number') {
+      gameState.setTrust(gameState.trust + m.effects.trust)
+    }
+    if (typeof m.effects.war === 'boolean') {
+      gameState.setWar(m.effects.war)
+    }
+
+    gameState.addActivatedMutation(m.id)
+    if (m.unlockCards.length) gameState.addUnlockedCards(m.unlockCards)
+    if (m.triggeredRumors.length) gameState.addRumors(m.triggeredRumors)
+
+    triggered.push(m)
+  }
+
+  return triggered
+}

--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -1,15 +1,24 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
+import { checkAndTriggerMutations } from '../../lib/mutationLogic'
 import ViewTurnScreen from '../view/ViewTurnScreen'
 
 export default function TurnScreen() {
-  const { setPlayerAdvice } = useGameState()
+  const {
+    setPlayerAdvice,
+    mainPlot,
+    currentTurn,
+    setCurrentTurn,
+  } = useGameState()
   const [advice, setAdvice] = useState('')
   const navigate = useNavigate()
 
   const handleSend = () => {
     setPlayerAdvice(advice)
+    const newTurn = currentTurn + 1
+    setCurrentTurn(newTurn)
+    checkAndTriggerMutations(newTurn, mainPlot, useGameState.getState())
     navigate('/reaction')
   }
 

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -36,6 +36,13 @@ export interface GameState {
   level: string
   mainPlot: Plot | null
   currentKing: King | null
+  currentTurn: number
+  prestige: number
+  trust: number
+  war: boolean
+  activatedMutations: string[]
+  unlockedCards: string[]
+  rumorsQueue: string[]
   setKingName: (name: string) => void
   setKingdom: (kingdom: string) => void
   setPlayerAdvice: (advice: string) => void
@@ -43,6 +50,13 @@ export interface GameState {
   setLevel: (level: string) => void
   setMainPlot: (plot: Plot) => void
   setCurrentKing: (king: King) => void
+  setCurrentTurn: (turn: number) => void
+  setPrestige: (value: number) => void
+  setTrust: (value: number) => void
+  setWar: (value: boolean) => void
+  addActivatedMutation: (id: string) => void
+  addUnlockedCards: (cards: string[]) => void
+  addRumors: (rumors: string[]) => void
   resetMainPlot: () => void
   resetState: () => void
 }
@@ -55,6 +69,13 @@ export const useGameState = create<GameState>((set) => ({
   level: '',
   mainPlot: null,
   currentKing: null,
+  currentTurn: 0,
+  prestige: 0,
+  trust: 0,
+  war: false,
+  activatedMutations: [],
+  unlockedCards: [],
+  rumorsQueue: [],
   setKingName: (kingName) => set({ kingName }),
   setKingdom: (kingdom) => set({ kingdom }),
   setPlayerAdvice: (playerAdvice) => set({ playerAdvice }),
@@ -62,7 +83,31 @@ export const useGameState = create<GameState>((set) => ({
   setLevel: (level) => set({ level }),
   setMainPlot: (mainPlot) => set({ mainPlot }),
   setCurrentKing: (currentKing) => set({ currentKing }),
+  setCurrentTurn: (currentTurn) => set({ currentTurn }),
+  setPrestige: (prestige) => set({ prestige }),
+  setTrust: (trust) => set({ trust }),
+  setWar: (war) => set({ war }),
+  addActivatedMutation: (id) =>
+    set((state) => ({ activatedMutations: [...state.activatedMutations, id] })),
+  addUnlockedCards: (cards) =>
+    set((state) => ({ unlockedCards: [...state.unlockedCards, ...cards] })),
+  addRumors: (rumors) =>
+    set((state) => ({ rumorsQueue: [...state.rumorsQueue, ...rumors] })),
   resetMainPlot: () => set({ mainPlot: null }),
   resetState: () =>
-    set({ kingName: '', kingdom: '', playerAdvice: '', kingReaction: '', level: '', currentKing: null }),
+    set({
+      kingName: '',
+      kingdom: '',
+      playerAdvice: '',
+      kingReaction: '',
+      level: '',
+      currentKing: null,
+      currentTurn: 0,
+      prestige: 0,
+      trust: 0,
+      war: false,
+      activatedMutations: [],
+      unlockedCards: [],
+      rumorsQueue: [],
+    }),
 }))


### PR DESCRIPTION
## Summary
- add example mutations to `mutationsPlot.json`
- extend global `GameState` with turn counters and mutation data
- create `checkAndTriggerMutations` helper and trigger it on turn end

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849d462579c8328b82c9b7d3813f649