### PR TITLE
Add narrative events system

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "reform_tax_system",
+    "title": "Tax Reform",
+    "description": "The kingdom's tax code is outdated and favors the elite.",
+    "level": "royal_court",
+    "tags": ["economy", "justice"],
+    "recommended_for": ["plot_reconstruction_balance"],
+    "conditions": {
+      "min_trust": 50,
+      "max_war": false
+    }
+  },
+  {
+    "id": "heal_faction_conflict",
+    "title": "Faction Reconciliation",
+    "description": "Tensions rise between rival factions within the council.",
+    "level": "governor",
+    "tags": ["politics", "unity"],
+    "recommended_for": ["plot_reconstruction_balance", "plot_border_flames"],
+    "conditions": {
+      "min_prestige": 30
+    }
+  },
+  {
+    "id": "secure_silk_routes",
+    "title": "Silk Route Secured",
+    "description": "Trade routes to the East are threatened by bandits and corruption.",
+    "level": "governor",
+    "tags": ["trade", "diplomacy"],
+    "recommended_for": ["plot_trading_intrigue"],
+    "conditions": {
+      "max_trust": 80,
+      "war": false
+    }
+  }
+]

--- a/src/lib/eventUtils.ts
+++ b/src/lib/eventUtils.ts
@@ -1,0 +1,38 @@
+import eventsData from '../data/events.json'
+import type { Plot, GameState } from '../state/gameState'
+
+export interface Event {
+  id: string
+  title: string
+  description: string
+  level: Plot['level']
+  tags: string[]
+  recommended_for: string[]
+  conditions: {
+    min_trust?: number
+    max_trust?: number
+    min_prestige?: number
+    max_prestige?: number
+    war?: boolean
+    max_war?: boolean
+  }
+}
+
+const events = eventsData as Event[]
+
+export function getEligibleEvents(plot: Plot, gameState: GameState): Event[] {
+  return events.filter((event) => {
+    if (event.level !== plot.level) return false
+    if (!event.recommended_for.includes(plot.id)) return false
+
+    const { conditions } = event
+    if (conditions.min_trust && gameState.trust < conditions.min_trust) return false
+    if (conditions.max_trust && gameState.trust > conditions.max_trust) return false
+    if (conditions.min_prestige && gameState.prestige < conditions.min_prestige) return false
+    if (conditions.max_prestige && gameState.prestige > conditions.max_prestige) return false
+    if (conditions.war !== undefined && gameState.war !== conditions.war) return false
+    if (conditions.max_war === false && gameState.war) return false
+
+    return true
+  })
+}

--- a/src/lib/narrative.ts
+++ b/src/lib/narrative.ts
@@ -1,6 +1,7 @@
 import { callAssistant } from './openai'
+import { getEligibleEvents, type Event } from './eventUtils'
 
-import type { Plot } from '../state/gameState'
+import type { Plot, GameState } from '../state/gameState'
 
 export const initialPlotPrompt = `Generate a JSON object representing a narrative plot for a medieval advisor game.
 The plot must follow this strict structure:
@@ -32,4 +33,19 @@ export async function generateInitialPlot(): Promise<Plot | null> {
     console.error('Failed to generate initial plot', error)
     return null
   }
+}
+
+export interface TurnContext {
+  event: Event | null
+}
+
+export function generateTurnContent(
+  plot: Plot,
+  gameState: GameState,
+): TurnContext {
+  const eligible = getEligibleEvents(plot, gameState)
+  const event = eligible.length > 0
+    ? eligible[Math.floor(Math.random() * eligible.length)]
+    : null
+  return { event }
 }

--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -25,8 +25,10 @@ export default function PresentationScreen() {
           const king = findMatchingKing(mainPlot)
           console.log('Using existing plot:', mainPlot)
           console.log('Selected king:', king)
-          setCurrentKing(king)
-          setKingName(`${king?.name} ${king?.epithet}`)
+          if (king) {
+            setCurrentKing(king)
+            setKingName(`${king.name} ${king.epithet}`)
+          }
           setKingdom(mainPlot.tags[0] || 'Eldoria')
         } else {
           setDebugText(`Prompt:\n${initialPlotPrompt}\n\n`)
@@ -37,8 +39,10 @@ export default function PresentationScreen() {
             setMainPlot(plot)
             const king = findMatchingKing(plot)
             console.log('Selected king:', king)
-            setCurrentKing(king)
-            setKingName(`${king?.name} ${king?.epithet}`)
+            if (king) {
+              setCurrentKing(king)
+              setKingName(`${king.name} ${king.epithet}`)
+            }
             setKingdom(plot.tags[0] || 'Eldoria')
           } else {
             setDebugText((prev) => prev + 'Fallback: plot was null\n')

--- a/src/screens/logic/ReactionScreen.tsx
+++ b/src/screens/logic/ReactionScreen.tsx
@@ -4,7 +4,7 @@ import { useGameState } from '../../state/gameState'
 import ViewReactionScreen from '../view/ViewReactionScreen'
 
 export default function ReactionScreen() {
-  const { kingName, playerAdvice, kingReaction, setKingReaction } = useGameState()
+  const { kingName, playerAdvice, kingReaction, currentEvent, setKingReaction } = useGameState()
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -20,6 +20,7 @@ export default function ReactionScreen() {
       kingName={kingName}
       playerAdvice={playerAdvice}
       kingReaction={kingReaction}
+      activeEvent={currentEvent ?? undefined}
       onEnd={handleEnd}
     />
   )

--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import { checkAndTriggerMutations } from '../../lib/mutationLogic'
+import { generateTurnContent } from '../../lib/narrative'
 import ViewTurnScreen from '../view/ViewTurnScreen'
 
 export default function TurnScreen() {
@@ -10,6 +11,7 @@ export default function TurnScreen() {
     mainPlot,
     currentTurn,
     setCurrentTurn,
+    setCurrentEvent,
   } = useGameState()
   const [advice, setAdvice] = useState('')
   const navigate = useNavigate()
@@ -18,6 +20,10 @@ export default function TurnScreen() {
     setPlayerAdvice(advice)
     const newTurn = currentTurn + 1
     setCurrentTurn(newTurn)
+    if (mainPlot) {
+      const { event } = generateTurnContent(mainPlot, useGameState.getState())
+      setCurrentEvent(event)
+    }
     checkAndTriggerMutations(newTurn, mainPlot, useGameState.getState())
     navigate('/reaction')
   }

--- a/src/screens/view/ViewReactionScreen.tsx
+++ b/src/screens/view/ViewReactionScreen.tsx
@@ -2,14 +2,21 @@ interface ViewReactionScreenProps {
   kingName: string
   playerAdvice: string
   kingReaction: string
+  activeEvent?: { title: string; description: string } | null
   onEnd: () => void
 }
 
-export default function ViewReactionScreen({ kingName, playerAdvice, kingReaction, onEnd }: ViewReactionScreenProps) {
+export default function ViewReactionScreen({ kingName, playerAdvice, kingReaction, activeEvent, onEnd }: ViewReactionScreenProps) {
   return (
     <div>
       <p>Your advice to King {kingName}: {playerAdvice}</p>
       <p>{kingReaction}</p>
+      {activeEvent && (
+        <div>
+          <h4>{activeEvent.title}</h4>
+          <p>{activeEvent.description}</p>
+        </div>
+      )}
       <button onClick={onEnd}>End Game</button>
     </div>
   )

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -43,6 +43,7 @@ export interface GameState {
   activatedMutations: string[]
   unlockedCards: string[]
   rumorsQueue: string[]
+  currentEvent: import('../lib/eventUtils').Event | null
   setKingName: (name: string) => void
   setKingdom: (kingdom: string) => void
   setPlayerAdvice: (advice: string) => void
@@ -57,6 +58,7 @@ export interface GameState {
   addActivatedMutation: (id: string) => void
   addUnlockedCards: (cards: string[]) => void
   addRumors: (rumors: string[]) => void
+  setCurrentEvent: (event: import('../lib/eventUtils').Event | null) => void
   resetMainPlot: () => void
   resetState: () => void
 }
@@ -76,6 +78,7 @@ export const useGameState = create<GameState>((set) => ({
   activatedMutations: [],
   unlockedCards: [],
   rumorsQueue: [],
+  currentEvent: null,
   setKingName: (kingName) => set({ kingName }),
   setKingdom: (kingdom) => set({ kingdom }),
   setPlayerAdvice: (playerAdvice) => set({ playerAdvice }),
@@ -93,6 +96,7 @@ export const useGameState = create<GameState>((set) => ({
     set((state) => ({ unlockedCards: [...state.unlockedCards, ...cards] })),
   addRumors: (rumors) =>
     set((state) => ({ rumorsQueue: [...state.rumorsQueue, ...rumors] })),
+  setCurrentEvent: (currentEvent) => set({ currentEvent }),
   resetMainPlot: () => set({ mainPlot: null }),
   resetState: () =>
     set({
@@ -109,5 +113,6 @@ export const useGameState = create<GameState>((set) => ({
       activatedMutations: [],
       unlockedCards: [],
       rumorsQueue: [],
+      currentEvent: null,
     }),
 }))

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,3 +34,25 @@ export interface Character {
   }
   visual?: string
 }
+
+export interface Event {
+  id: string
+  title: string
+  description: string
+  level:
+    | 'village'
+    | 'governor'
+    | 'royal_court'
+    | 'mythical_kingdom'
+    | 'legendary_oracle'
+  tags: string[]
+  recommended_for: string[]
+  conditions: {
+    min_trust?: number
+    max_trust?: number
+    min_prestige?: number
+    max_prestige?: number
+    war?: boolean
+    max_war?: boolean
+  }
+}


### PR DESCRIPTION
## Summary
- introduce new events data
- create event utilities to find eligible events per plot and game state
- update narrative logic with `generateTurnContent`
- store active events in game state and surface them in the UI
- show events during the reaction screen

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849e7bab32c8328aa37b2b9ac52947c