### PR TITLE
Add reusable scenes injection

### DIFF
--- a/src/data/reusable_scenes.json
+++ b/src/data/reusable_scenes.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "ritual_of_ashes",
+    "title": "The Ritual of Ashes",
+    "description": "In a hollowed-out chapel, nobles gather in silence. The scent of burnt paper and old incense lingers in the air.",
+    "tags": ["ritual", "mourning"],
+    "level": "royal_court",
+    "tone": "dark",
+    "visual": "chapel_candles_ashes",
+    "linked_plot_tags": ["legacy", "loss"],
+    "conditions": {
+      "prestige_below": 40,
+      "war": false
+    }
+  },
+  {
+    "id": "market_whispers",
+    "title": "Whispers in the Market",
+    "description": "A merchant pauses mid-sale to mutter about the royal bloodline. Ears perk, deals pause.",
+    "tags": ["rumor", "tension"],
+    "level": "village",
+    "tone": "neutral",
+    "visual": "marketplace_shadows_listeners",
+    "linked_plot_tags": ["intrigue", "deception"],
+    "conditions": {
+      "trust_below": 60
+    }
+  }
+]

--- a/src/lib/narrative.ts
+++ b/src/lib/narrative.ts
@@ -1,7 +1,63 @@
 import { callAssistant } from './openai'
 import { getEligibleEvents, type Event } from './eventUtils'
-
+import scenesData from '../data/reusable_scenes.json'
 import type { Plot, GameState } from '../state/gameState'
+
+export interface ReusableScene {
+  id: string
+  title: string
+  description: string
+  tags: string[]
+  level: Plot['level']
+  tone: string
+  visual: string
+  linked_plot_tags?: string[]
+  conditions?: Record<string, unknown>
+}
+
+const scenes = scenesData as ReusableScene[]
+
+function conditionsMet(scene: ReusableScene, gameState: GameState): boolean {
+  if (!scene.conditions) return true
+  for (const [key, value] of Object.entries(scene.conditions)) {
+    switch (key) {
+      case 'prestige_below':
+        if (!(gameState.prestige < Number(value))) return false
+        break
+      case 'prestige_above':
+        if (!(gameState.prestige > Number(value))) return false
+        break
+      case 'trust_below':
+        if (!(gameState.trust < Number(value))) return false
+        break
+      case 'trust_above':
+        if (!(gameState.trust > Number(value))) return false
+        break
+      case 'war':
+        if (gameState.war !== value) return false
+        break
+      case 'war_true':
+        if (value && !gameState.war) return false
+        break
+      case 'war_false':
+        if (value && gameState.war) return false
+        break
+      default:
+        break
+    }
+  }
+  return true
+}
+
+function getEligibleScenes(plot: Plot, gameState: GameState): ReusableScene[] {
+  return scenes.filter((s) => {
+    if (s.level !== plot.level) return false
+    if (s.linked_plot_tags && !s.linked_plot_tags.some((t) => plot.tags.includes(t))) {
+      return false
+    }
+    return conditionsMet(s, gameState)
+  })
+}
 
 export const initialPlotPrompt = `Generate a JSON object representing a narrative plot for a medieval advisor game.
 The plot must follow this strict structure:
@@ -37,6 +93,8 @@ export async function generateInitialPlot(): Promise<Plot | null> {
 
 export interface TurnContext {
   event: Event | null
+  sceneDescription: string
+  sceneVisual: string | null
 }
 
 export function generateTurnContent(
@@ -47,5 +105,14 @@ export function generateTurnContent(
   const event = eligible.length > 0
     ? eligible[Math.floor(Math.random() * eligible.length)]
     : null
-  return { event }
+  const possibleScenes = getEligibleScenes(plot, gameState)
+  const scene = possibleScenes.length > 0
+    ? possibleScenes[Math.floor(Math.random() * possibleScenes.length)]
+    : null
+  const fallback = 'The court murmurs restlessly while shadows gather in the corners of the hall.'
+  return {
+    event,
+    sceneDescription: scene ? scene.description : fallback,
+    sceneVisual: scene ? scene.visual : null,
+  }
 }


### PR DESCRIPTION
## Summary
- add `reusable_scenes.json` with example scenes
- extend `narrative.ts` to load reusable scenes
- implement filtering and selection logic for scenes
- expose chosen scene with description/visual in turn context

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849e969c0208328a2079239e798b60a