### PR TITLE
Add plot phases data and retrieval utils

### DIFF
--- a/src/data/plot_phases.json
+++ b/src/data/plot_phases.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "phase_reconstruction_hint",
+    "plotId": "plot_reconstruction_balance",
+    "phaseType": "hint",
+    "title": "Echoes of the War",
+    "summary": "Even after peace was declared, some wounds refuse to heal.",
+    "mood": "uncertain",
+    "visual": "village_ruins_calm_mist",
+    "tags": ["reconstruction", "recovery"],
+    "forcedAdvanceAfter": 2
+  },
+  {
+    "id": "phase_reconstruction_conflict",
+    "plotId": "plot_reconstruction_balance",
+    "phaseType": "conflict",
+    "title": "The Tax Revolt",
+    "summary": "A noble-led rebellion erupts in response to sweeping reforms.",
+    "mood": "tense",
+    "visual": "angry_nobles_castle_courtyard",
+    "tags": ["resistance", "law"],
+    "forcedAdvanceAfter": 3
+  }
+]

--- a/src/lib/plotPhases.ts
+++ b/src/lib/plotPhases.ts
@@ -1,0 +1,28 @@
+import plotPhasesData from '../data/plot_phases.json'
+
+export interface PlotPhase {
+  id: string
+  plotId: string
+  phaseType: 'hint' | 'conflict' | 'climax'
+  title: string
+  summary: string
+  mood: string
+  visual: string
+  tags: string[]
+  forcedAdvanceAfter: number
+}
+
+const plotPhases = plotPhasesData as PlotPhase[]
+
+export function getPhasesForPlot(plotId: string): PlotPhase[] {
+  return plotPhases.filter((phase) => phase.plotId === plotId)
+}
+
+export function getPhaseByType(
+  plotId: string,
+  phaseType: 'hint' | 'conflict' | 'climax',
+): PlotPhase | undefined {
+  return plotPhases.find(
+    (phase) => phase.plotId === plotId && phase.phaseType === phaseType,
+  )
+}


### PR DESCRIPTION
## Summary
- add `plot_phases.json` with sample plot phase entries
- create `plotPhases.ts` to fetch phases for a plot or by type

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849eaa9055483288d249eeff7d619eb