### PR TITLE
Add kingdoms data and selection logic

### DIFF
--- a/src/data/kingdoms.json
+++ b/src/data/kingdoms.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "desertic_empire_south",
+    "name": "Empire of the Dunes",
+    "motto": "Where the sun burns lies and the wind buries secrets.",
+    "description": "A vast empire ruled by old laws and shifting sands. Once glorious, now fractured by hidden wars.",
+    "visual_style": {
+      "palette": "gold_sand_red_cloth",
+      "architecture": "mud bricks, towers, domes",
+      "landmarks": ["Pyramid of Kings", "Cavern of Whispers"]
+    },
+    "narrative_tags": ["desert", "tradition", "secrecy", "ruin"],
+    "levels_available": ["village", "governor", "royal_court"],
+    "default_weather": "scorching sun",
+    "season_cycle": ["Drought Moon", "Storm Time", "Pilgrim's Shade", "Wind Fall"],
+    "symbolic_elements": ["scorpion", "sun disk", "sand spiral"],
+    "visual_prompt_tag": "ancient desert kingdom with pyramids and golden banners under blazing sun",
+    "recommended_plot_tags": ["betrayal", "legacy", "dust"],
+    "recommended_kings": ["king_thorne_warborn", "king_lauren_cunning"]
+  },
+  {
+    "id": "highland_vales_north",
+    "name": "Highland Vales",
+    "motto": "Peace blooms where vigilance reigns.",
+    "description": "A mountain kingdom of isolated strongholds and stubborn clans. Harsh winters, silent loyalty.",
+    "visual_style": {
+      "palette": "gray_stone_green_heraldry",
+      "architecture": "castles, watchtowers, snowy roofs",
+      "landmarks": ["Eagle Spire", "Frozen Pact Bridge"]
+    },
+    "narrative_tags": ["loyalty", "honor", "isolation", "tradition"],
+    "levels_available": ["village", "governor", "royal_court", "mythical_kingdom"],
+    "default_weather": "snowfall",
+    "season_cycle": ["Thaw", "Huntmoon", "Frostshard", "Longdark"],
+    "symbolic_elements": ["eagle", "pine", "blood oath"],
+    "visual_prompt_tag": "frozen highland kingdom with stone towers and clan banners in snowstorm",
+    "recommended_plot_tags": ["sacrifice", "conflict", "legacy"],
+    "recommended_kings": ["king_aldric_justo", "king_feron_just"]
+  }
+]

--- a/src/lib/kingdomSelector.ts
+++ b/src/lib/kingdomSelector.ts
@@ -1,0 +1,19 @@
+import kingdoms from '../data/kingdoms.json'
+import type { Plot } from '../state/gameState'
+import type { Kingdom } from '../types'
+
+export function findMatchingKingdom(plot: Plot, level: string): Kingdom | null {
+  const filtered = (kingdoms as Kingdom[]).filter(k => k.levels_available.includes(level))
+  let bestMatch: Kingdom | null = null
+  let maxScore = 0
+
+  for (const kingdom of filtered) {
+    const score = kingdom.narrative_tags.filter(tag => plot.tags.includes(tag)).length
+    if (score > maxScore) {
+      bestMatch = kingdom
+      maxScore = score
+    }
+  }
+
+  return bestMatch
+}

--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import { generateInitialPlot, initialPlotPrompt } from '../../lib/narrative'
 import { findMatchingKing } from '../../lib/kingSelector'
+import { findMatchingKingdom } from '../../lib/kingdomSelector'
+import type { Kingdom } from '../../types'
 import ViewPresentationScreen from '../view/ViewPresentationScreen'
 
 export default function PresentationScreen() {
@@ -17,11 +19,17 @@ export default function PresentationScreen() {
   } = useGameState()
   const navigate = useNavigate()
   const [debugText, setDebugText] = useState('')
+  const [selectedKingdom, setSelectedKingdom] = useState<Kingdom | null>(null)
 
   useEffect(() => {
     const init = async () => {
       try {
         if (mainPlot) {
+          const kingdomMatch = findMatchingKingdom(mainPlot, mainPlot.level)
+          if (kingdomMatch) {
+            setSelectedKingdom(kingdomMatch)
+            setKingdom(kingdomMatch.name)
+          }
           const king = findMatchingKing(mainPlot)
           console.log('Using existing plot:', mainPlot)
           console.log('Selected king:', king)
@@ -29,7 +37,7 @@ export default function PresentationScreen() {
             setCurrentKing(king)
             setKingName(`${king.name} ${king.epithet}`)
           }
-          setKingdom(mainPlot.tags[0] || 'Eldoria')
+          if (!kingdomMatch) setKingdom(mainPlot.tags[0] || 'Eldoria')
         } else {
           setDebugText(`Prompt:\n${initialPlotPrompt}\n\n`)
           const plot = await generateInitialPlot()
@@ -37,13 +45,18 @@ export default function PresentationScreen() {
           console.log('Generated plot:', plot)
           if (plot) {
             setMainPlot(plot)
+            const kingdomMatch = findMatchingKingdom(plot, plot.level)
+            if (kingdomMatch) {
+              setSelectedKingdom(kingdomMatch)
+              setKingdom(kingdomMatch.name)
+            }
             const king = findMatchingKing(plot)
             console.log('Selected king:', king)
             if (king) {
               setCurrentKing(king)
               setKingName(`${king.name} ${king.epithet}`)
             }
-            setKingdom(plot.tags[0] || 'Eldoria')
+            if (!kingdomMatch) setKingdom(plot.tags[0] || 'Eldoria')
           } else {
             setDebugText((prev) => prev + 'Fallback: plot was null\n')
           }
@@ -63,7 +76,8 @@ export default function PresentationScreen() {
   return (
     <ViewPresentationScreen
       kingName={kingName}
-      kingdom={kingdom}
+      kingdom={selectedKingdom ? selectedKingdom.name : kingdom}
+      kingdomDescription={selectedKingdom?.description}
       onContinue={handleContinue}
       debugText={debugText}
     />

--- a/src/screens/view/ViewPresentationScreen.tsx
+++ b/src/screens/view/ViewPresentationScreen.tsx
@@ -3,11 +3,12 @@ import { useGameState } from '../../state/gameState'
 interface ViewPresentationScreenProps {
   kingName: string
   kingdom: string
+  kingdomDescription?: string
   onContinue: () => void
   debugText: string
 }
 
-export default function ViewPresentationScreen({ kingName, kingdom, onContinue, debugText }: ViewPresentationScreenProps) {
+export default function ViewPresentationScreen({ kingName, kingdom, kingdomDescription, onContinue, debugText }: ViewPresentationScreenProps) {
   const { currentKing, mainPlot } = useGameState()
   const name = currentKing?.name || kingName
   const epithet = currentKing?.epithet || ''
@@ -15,6 +16,7 @@ export default function ViewPresentationScreen({ kingName, kingdom, onContinue, 
   const phrase = currentKing?.king_phrase || 'Long live the king.'
   const throneDesc = currentKing?.throne_room_description || 'The throne room awaits.'
   const kingdomContext = currentKing?.kingdom_context || `The kingdom of ${kingdom}`
+  const kingdomDesc = kingdomDescription || ''
   const personality = currentKing?.personality || 'Unknown'
   const tone = currentKing?.general_tone || 'Neutral'
 
@@ -47,6 +49,7 @@ export default function ViewPresentationScreen({ kingName, kingdom, onContinue, 
         <div style={{ flex: 1, textAlign: 'left' }}>
           <p>{throneDesc}</p>
           <p>{kingdomContext}</p>
+          {kingdomDesc && <p>{kingdomDesc}</p>}
         </div>
 
         <div

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,3 +56,24 @@ export interface Event {
     max_war?: boolean
   }
 }
+
+export interface Kingdom {
+  id: string
+  name: string
+  motto: string
+  description: string
+  visual_style: {
+    palette: string
+    architecture: string
+    landmarks: string[]
+  }
+  narrative_tags: string[]
+  levels_available: string[]
+  default_weather?: string
+  season_cycle?: string[]
+  symbolic_elements?: string[]
+  visual_prompt_tag: string
+  recommended_plot_tags?: string[]
+  recommended_kings?: string[]
+}
+


### PR DESCRIPTION
## Summary
- add kingdoms examples under `src/data`
- define new `Kingdom` interface
- implement `findMatchingKingdom` helper
- include kingdom selection in `PresentationScreen`
- show kingdom description in presentation view

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851392814288328b69d9ceb175ca855