### PR TITLE
Add events and twists data

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -34,5 +34,23 @@
       "max_turn": 5
     },
     "visual": "caravan_guarded_by_soldiers"
+  },
+  {
+    "id": "event_smuggler_ambush",
+    "title": "Smuggler Ambush in the Dunes",
+    "description": "A convoy was attacked under suspicious circumstances. Some say the guards opened the gates themselves.",
+    "impactTags": ["betrayal", "secrecy", "desert"],
+    "visual": {
+      "tag_ia": "desert ambush with broken wagons and masked figures"
+    }
+  },
+  {
+    "id": "event_old_oath_revealed",
+    "title": "The Forgotten Oath Resurfaces",
+    "description": "Ancient writings found in a ruined monastery mention a blood pact tied to the northern clans.",
+    "impactTags": ["legacy", "mystery", "loyalty"],
+    "visual": {
+      "tag_ia": "ancient scroll glowing in snowy ruins"
+    }
   }
 ]

--- a/src/data/twists.json
+++ b/src/data/twists.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "twist_traitor_guard",
+    "title": "A Guard's Confession",
+    "description": "A royal guard secretly admits to accepting bribes from a noble faction.",
+    "impactTags": ["corruption", "betrayal", "fear"],
+    "visual": {
+      "tag_ia": "guard in shadows whispering confession in torch-lit corridor"
+    }
+  },
+  {
+    "id": "twist_unexpected_heir",
+    "title": "Claim of the Lost Heir",
+    "description": "A figure claiming to be the true heir of the northern throne demands an audience.",
+    "impactTags": ["identity", "legacy", "shock"],
+    "visual": {
+      "tag_ia": "hooded figure holding royal crest in snowy court"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- include new plot events for betrayal_in_the_dunes and the_forgotten_oath
- add twist definitions to separate file

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68513a3b16f08328b93d6457d75b0e63