### PR TITLE
Implement rumor selection system

### DIFF
--- a/src/data/rumors.json
+++ b/src/data/rumors.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "rumor_low_taxes",
+    "text": "Whispers say the King plans to lower taxes... or raise them.",
+    "emotion_tags": ["distrust", "curiosity"],
+    "kingdom_tags": ["reform", "instability"],
+    "level": ["village", "governor"],
+    "intensity": "low",
+    "visual": {
+      "tag_ia": "peasants murmuring around village fire"
+    }
+  }
+]

--- a/src/lib/rumorSelector.ts
+++ b/src/lib/rumorSelector.ts
@@ -1,0 +1,25 @@
+import rumors from '../data/rumors.json'
+import type { GameState } from '../state/gameState'
+
+export function selectRumor(state: GameState): string | null {
+  const emotion = state.currentEmotion || []
+  const kingdomTags = state.mainPlot?.tags || []
+  const level = state.level
+
+  const candidates = (rumors as unknown as Array<{
+    id: string
+    text: string
+    emotion_tags?: string[]
+    kingdom_tags?: string[]
+    level?: string[]
+  }>).filter((rumor) =>
+    (!rumor.level || rumor.level.includes(level)) &&
+    (!rumor.emotion_tags || rumor.emotion_tags.some((e) => emotion.includes(e))) &&
+    (!rumor.kingdom_tags || rumor.kingdom_tags.some((t) => kingdomTags.includes(t)))
+  )
+
+  if (candidates.length === 0) return null
+
+  const chosen = candidates[Math.floor(Math.random() * candidates.length)]
+  return chosen.text
+}

--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -4,15 +4,18 @@ import { useGameState } from '../../state/gameState'
 import { checkAndTriggerMutations } from '../../lib/mutationLogic'
 import { getAvailableEvents } from '../../lib/eventSelector'
 import ViewTurnScreen from '../view/ViewTurnScreen'
+import { selectRumor } from '../../lib/rumorSelector'
 
 export default function TurnScreen() {
+  const gameState = useGameState()
   const {
     setPlayerAdvice,
     mainPlot,
     currentTurn,
     setCurrentTurn,
     setActiveEvents,
-  } = useGameState()
+  } = gameState
+  const rumor = selectRumor(gameState)
   const [advice, setAdvice] = useState('')
   const navigate = useNavigate()
 
@@ -30,6 +33,7 @@ export default function TurnScreen() {
 
   return (
     <ViewTurnScreen
+      rumor={rumor}
       advice={advice}
       onAdviceChange={setAdvice}
       onSend={handleSend}

--- a/src/screens/view/ViewTurnScreen.tsx
+++ b/src/screens/view/ViewTurnScreen.tsx
@@ -1,12 +1,14 @@
 interface ViewTurnScreenProps {
+  rumor?: string | null
   advice: string
   onAdviceChange: (value: string) => void
   onSend: () => void
 }
 
-export default function ViewTurnScreen({ advice, onAdviceChange, onSend }: ViewTurnScreenProps) {
+export default function ViewTurnScreen({ rumor, advice, onAdviceChange, onSend }: ViewTurnScreenProps) {
   return (
     <div>
+      {rumor && <p>{rumor}</p>}
       <p>The villagers have gathered in the square with torches.</p>
       <p>Should we intervene or let them speak freely?</p>
       <textarea

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -43,6 +43,7 @@ export interface GameState {
   war: boolean
   activatedMutations: string[]
   unlockedCards: string[]
+  currentEmotion: string[]
   rumorsQueue: string[]
   activeEvents: PlotEvent[],
   currentEvent: import('../lib/eventUtils').Event | null
@@ -60,6 +61,7 @@ export interface GameState {
   addActivatedMutation: (id: string) => void
   setActiveEvents: (events: PlotEvent[]) => void,
   addUnlockedCards: (cards: string[]) => void
+  setCurrentEmotion: (emotion: string[]) => void
   addRumors: (rumors: string[]) => void
   setCurrentEvent: (event: import('../lib/eventUtils').Event | null) => void
   resetMainPlot: () => void
@@ -80,6 +82,7 @@ export const useGameState = create<GameState>((set) => ({
   war: false,
   activatedMutations: [],
   unlockedCards: [],
+  currentEmotion: [],
   rumorsQueue: [],
   currentEvent: null,
   activeEvents: [],
@@ -94,6 +97,7 @@ export const useGameState = create<GameState>((set) => ({
   setPrestige: (prestige) => set({ prestige }),
   setTrust: (trust) => set({ trust }),
   setWar: (war) => set({ war }),
+  setCurrentEmotion: (currentEmotion) => set({ currentEmotion }),
   addActivatedMutation: (id) =>
     set((state) => ({ activatedMutations: [...state.activatedMutations, id] })),
   addUnlockedCards: (cards) =>
@@ -118,6 +122,7 @@ export const useGameState = create<GameState>((set) => ({
       activatedMutations: [],
       unlockedCards: [],
       activeEvents: [],
+      currentEmotion: [],
       rumorsQueue: [],
       currentEvent: null,
     }),


### PR DESCRIPTION
## Summary
- add `rumors.json` dataset
- implement `rumorSelector` utility
- expose `currentEmotion` in game state
- show a rumor on the turn screen

## Testing
- `npm run build`
- `npm run lint`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68513f9b553883289cadee3a2d1430db