### PR TITLE
Display rumor from queue during turns

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,28 @@
 .read-the-docs {
   color: #888;
 }
+
+.rumor-box {
+  background-color: #1a1a1a;
+  border-left: 4px solid #999;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border-radius: 0.5rem;
+  animation: fadeIn 0.6s ease-in-out;
+}
+
+.rumor-text {
+  color: #ccc;
+  font-style: italic;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -5,6 +5,14 @@ import { checkAndTriggerMutations } from '../../lib/mutationLogic'
 import { getAvailableEvents } from '../../lib/eventSelector'
 import ViewTurnScreen from '../view/ViewTurnScreen'
 import { selectRumor, getMatchingRumors } from '../../lib/rumorSelector'
+import rumors from '../../data/rumors.json'
+
+function getRumorTextById(id: string): string {
+  const found = (rumors as Array<{ id: string; text: string }>).find(
+    (r) => r.id === id,
+  )
+  return found?.text || ''
+}
 
 export default function TurnScreen() {
   const gameState = useGameState()
@@ -15,6 +23,7 @@ export default function TurnScreen() {
     setCurrentTurn,
     setActiveEvents,
     addRumors,
+    rumorsQueue,
   } = gameState
   const matchingRumors = getMatchingRumors(
     gameState.currentEmotion || [],
@@ -25,6 +34,8 @@ export default function TurnScreen() {
   useEffect(() => {
     if (rumor) addRumors([rumor])
   }, [rumor, addRumors])
+  const currentRumorId = rumorsQueue.length > 0 ? rumorsQueue[0] : null
+  const currentRumorText = currentRumorId ? getRumorTextById(currentRumorId) : ''
   const [advice, setAdvice] = useState('')
   const navigate = useNavigate()
 
@@ -42,7 +53,7 @@ export default function TurnScreen() {
 
   return (
     <ViewTurnScreen
-      rumor={rumor}
+      rumor={currentRumorText}
       advice={advice}
       onAdviceChange={setAdvice}
       onSend={handleSend}

--- a/src/screens/view/ViewTurnScreen.tsx
+++ b/src/screens/view/ViewTurnScreen.tsx
@@ -8,7 +8,11 @@ interface ViewTurnScreenProps {
 export default function ViewTurnScreen({ rumor, advice, onAdviceChange, onSend }: ViewTurnScreenProps) {
   return (
     <div>
-      {rumor && <p>{rumor}</p>}
+      {rumor && (
+        <div className="rumor-box">
+          <p className="rumor-text">🕵️ Rumor: {rumor}</p>
+        </div>
+      )}
       <p>The villagers have gathered in the square with torches.</p>
       <p>Should we intervene or let them speak freely?</p>
       <textarea


### PR DESCRIPTION
## Summary
- fetch rumor text from dataset by id
- render first queued rumor on the turn screen
- style rumor box

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851458ba4c08328902e4ba3745dfc20