### PR TITLE
Remove queued rumor after display

### DIFF
--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -24,6 +24,7 @@ export default function TurnScreen() {
     setActiveEvents,
     addRumors,
     rumorsQueue,
+    setRumorsQueue,
   } = gameState
   const matchingRumors = getMatchingRumors(
     gameState.currentEmotion || [],
@@ -34,7 +35,19 @@ export default function TurnScreen() {
   useEffect(() => {
     if (rumor) addRumors([rumor])
   }, [rumor, addRumors])
-  const currentRumorId = rumorsQueue.length > 0 ? rumorsQueue[0] : null
+
+  const [currentRumorId, setCurrentRumorId] = useState<string | null>(null)
+
+  // Remove the first rumor after it is shown once
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    if (rumorsQueue.length > 0) {
+      setCurrentRumorId(rumorsQueue[0])
+      setRumorsQueue(rumorsQueue.slice(1))
+    }
+  }, [])
+  /* eslint-enable react-hooks/exhaustive-deps */
+
   const currentRumorText = currentRumorId ? getRumorTextById(currentRumorId) : ''
   const [advice, setAdvice] = useState('')
   const navigate = useNavigate()

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -63,6 +63,7 @@ export interface GameState {
   addUnlockedCards: (cards: string[]) => void
   setCurrentEmotion: (emotion: string[]) => void
   addRumors: (rumors: string[]) => void
+  setRumorsQueue: (queue: string[]) => void
   setCurrentEvent: (event: import('../lib/eventUtils').Event | null) => void
   resetMainPlot: () => void
   resetState: () => void
@@ -105,6 +106,7 @@ export const useGameState = create<GameState>((set) => ({
   setActiveEvents: (activeEvents) => set({ activeEvents }),
   addRumors: (rumors) =>
     set((state) => ({ rumorsQueue: [...state.rumorsQueue, ...rumors] })),
+  setRumorsQueue: (rumorsQueue) => set({ rumorsQueue }),
   setCurrentEvent: (currentEvent) => set({ currentEvent }),
   resetMainPlot: () => set({ mainPlot: null }),
   resetState: () =>


### PR DESCRIPTION
## Summary
- add `setRumorsQueue` mutation in `useGameState`
- dequeue the first rumor on `TurnScreen` mount

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685146df51dc83288a690f45f68ce013