### PR TITLE
Add rumor text lookup utility

### DIFF
--- a/src/lib/rumorUtils.ts
+++ b/src/lib/rumorUtils.ts
@@ -1,0 +1,20 @@
+import rumorsData from '../data/rumors.json'
+
+export interface Rumor {
+  id: string
+  text: string
+  level?: string[]
+  tags?: string[]
+  conditions?: {
+    prestigeAbove?: number
+    trustBelow?: number
+    war?: boolean
+  }
+}
+
+const rumors = rumorsData as Rumor[]
+
+export function getRumorTextById(id: string): string {
+  const found = rumors.find(r => r.id === id)
+  return found?.text || '[Missing rumor text]'
+}

--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -5,14 +5,7 @@ import { checkAndTriggerMutations } from '../../lib/mutationLogic'
 import { getAvailableEvents } from '../../lib/eventSelector'
 import ViewTurnScreen from '../view/ViewTurnScreen'
 import { selectRumor, getMatchingRumors } from '../../lib/rumorSelector'
-import rumors from '../../data/rumors.json'
-
-function getRumorTextById(id: string): string {
-  const found = (rumors as Array<{ id: string; text: string }>).find(
-    (r) => r.id === id,
-  )
-  return found?.text || ''
-}
+import { getRumorTextById } from '../../lib/rumorUtils'
 
 export default function TurnScreen() {
   const gameState = useGameState()


### PR DESCRIPTION
## Summary
- add `getRumorTextById` helper in `rumorUtils`
- use the new helper in `TurnScreen`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851477599e883289e80299ea4ff78fe