### PR TITLE
Add rumor filtering logic

### DIFF
--- a/src/lib/rumorUtils.ts
+++ b/src/lib/rumorUtils.ts
@@ -1,4 +1,5 @@
 import rumorsData from '../data/rumors.json'
+import { useGameState } from '../state/gameState'
 
 export interface Rumor {
   id: string
@@ -17,4 +18,24 @@ const rumors = rumorsData as Rumor[]
 export function getRumorTextById(id: string): string {
   const found = rumors.find(r => r.id === id)
   return found?.text || '[Missing rumor text]'
+}
+
+export function getValidRumors(): Rumor[] {
+  const { level, prestige, trust, war } = useGameState.getState()
+  return rumors.filter(rumor => {
+    if (rumor.level && !rumor.level.includes(level)) return false
+    const cond = rumor.conditions
+    if (!cond) return true
+    if (cond.prestigeAbove !== undefined && prestige <= cond.prestigeAbove) return false
+    if (cond.trustBelow !== undefined && trust >= cond.trustBelow) return false
+    if (cond.war !== undefined && war !== cond.war) return false
+    return true
+  })
+}
+
+export function pickRandomRumor(): string {
+  const validRumors = getValidRumors()
+  if (validRumors.length === 0) return 'The realm is silent...'
+  const randomIndex = Math.floor(Math.random() * validRumors.length)
+  return validRumors[randomIndex].text
 }


### PR DESCRIPTION
## Summary
- add utilities to filter rumors based on game state
- expose `pickRandomRumor` to select a random valid rumor

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685148767b94832895abdcd970dbef5a