### PR TITLE
Implement automatic rumor system

### DIFF
--- a/src/data/rumors.json
+++ b/src/data/rumors.json
@@ -6,9 +6,7 @@
     "kingdom_tags": ["reform", "instability"],
     "level": ["village", "governor"],
     "intensity": "low",
-    "visual": {
-      "tag_ia": "peasants murmuring around village fire"
-    }
+    "visual": {"tag_ia": "peasants murmuring around village fire"}
   },
   {
     "id": "rumor_shadow_council",
@@ -17,9 +15,7 @@
     "kingdom_tags": ["power", "intrigue"],
     "level": ["royal_court", "mythical_kingdom"],
     "intensity": "medium",
-    "visual": {
-      "tag_ia": "hooded figures in dark chamber whispering behind throne"
-    }
+    "visual": {"tag_ia": "hooded figures in dark chamber whispering behind throne"}
   },
   {
     "id": "rumor_return_of_heir",
@@ -28,8 +24,76 @@
     "kingdom_tags": ["legacy", "loyalty"],
     "level": ["governor", "mythical_kingdom"],
     "intensity": "high",
-    "visual": {
-      "tag_ia": "hooded figure with royal crest in snowy forest"
-    }
+    "visual": {"tag_ia": "hooded figure with royal crest in snowy forest"}
+  },
+  {
+    "id": "rumor_reform_wave",
+    "text": "Taverns buzz about sweeping reforms soon to shake the realm.",
+    "emotion_tags": ["hope", "curiosity"],
+    "kingdom_tags": ["reform"],
+    "level": ["governor", "royal_court"],
+    "intensity": "medium",
+    "conditions": {"prestigeAbove": 5},
+    "visual": {"tag_ia": "scholars debating scrolls of new laws"}
+  },
+  {
+    "id": "rumor_murder_in_court",
+    "text": "A courtier whispers that a noble was slain within the palace walls.",
+    "emotion_tags": ["fear", "distrust"],
+    "kingdom_tags": ["power", "intrigue"],
+    "level": ["royal_court"],
+    "intensity": "high",
+    "conditions": {"trustBelow": 60, "war": false},
+    "visual": {"tag_ia": "bloodied dagger on embroidered cushion"}
+  },
+  {
+    "id": "rumor_tax_resistance",
+    "text": "Some villagers refuse to pay the latest taxes, quietly banding together.",
+    "emotion_tags": ["anger", "distrust"],
+    "kingdom_tags": ["economy", "dissent"],
+    "level": ["village"],
+    "intensity": "low",
+    "conditions": {"trustBelow": 50},
+    "visual": {"tag_ia": "peasants hiding coins from royal collectors"}
+  },
+  {
+    "id": "rumor_border_threat",
+    "text": "Scouts report enemy banners seen beyond the eastern hills.",
+    "emotion_tags": ["fear"],
+    "kingdom_tags": ["war"],
+    "level": ["governor", "royal_court"],
+    "intensity": "medium",
+    "conditions": {"war": true},
+    "visual": {"tag_ia": "watchtower spotting distant army"}
+  },
+  {
+    "id": "rumor_mysterious_prophet",
+    "text": "A wandering prophet predicts doom unless the king heeds ancient omens.",
+    "emotion_tags": ["fear", "confusion"],
+    "kingdom_tags": ["mysticism"],
+    "level": ["mythical_kingdom", "legendary_oracle"],
+    "intensity": "high",
+    "conditions": {"trustBelow": 40},
+    "visual": {"tag_ia": "robed seer speaking before awed crowd"}
+  },
+  {
+    "id": "rumor_bandit_activity",
+    "text": "Merchants complain of bandits growing bold along the trade roads.",
+    "emotion_tags": ["anger"],
+    "kingdom_tags": ["economy", "instability"],
+    "level": ["village", "governor"],
+    "intensity": "low",
+    "conditions": {"war": false},
+    "visual": {"tag_ia": "bandits ambushing caravan at dusk"}
+  },
+  {
+    "id": "rumor_secret_alliance",
+    "text": "Rumor has it the king seeks a secret pact with a rival realm.",
+    "emotion_tags": ["curiosity", "distrust"],
+    "kingdom_tags": ["intrigue", "diplomacy"],
+    "level": ["royal_court", "mythical_kingdom"],
+    "intensity": "medium",
+    "conditions": {"war": false, "prestigeAbove": 10},
+    "visual": {"tag_ia": "royal envoy meeting in candlelit chamber"}
   }
 ]

--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -4,8 +4,7 @@ import { useGameState } from '../../state/gameState'
 import { checkAndTriggerMutations } from '../../lib/mutationLogic'
 import { getAvailableEvents } from '../../lib/eventSelector'
 import ViewTurnScreen from '../view/ViewTurnScreen'
-import { selectRumor, getMatchingRumors } from '../../lib/rumorSelector'
-import { getRumorTextById } from '../../lib/rumorUtils'
+import { pickRandomRumor } from '../../lib/rumorSelector'
 
 export default function TurnScreen() {
   const gameState = useGameState()
@@ -17,31 +16,19 @@ export default function TurnScreen() {
     setActiveEvents,
     addRumors,
     rumorsQueue,
-    setRumorsQueue,
   } = gameState
-  const matchingRumors = getMatchingRumors(
-    gameState.currentEmotion || [],
-    mainPlot?.tags || [],
-    gameState.level,
-  )
-  const rumor = matchingRumors.length > 0 ? selectRumor(gameState) : null
-  useEffect(() => {
-    if (rumor) addRumors([rumor])
-  }, [rumor, addRumors])
 
-  const [currentRumorId, setCurrentRumorId] = useState<string | null>(null)
-
-  // Remove the first rumor after it is shown once
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
-    if (rumorsQueue.length > 0) {
-      setCurrentRumorId(rumorsQueue[0])
-      setRumorsQueue(rumorsQueue.slice(1))
+    const rumor = pickRandomRumor(useGameState.getState())
+    if (rumor && !rumorsQueue.includes(rumor)) {
+      addRumors([rumor])
     }
   }, [])
   /* eslint-enable react-hooks/exhaustive-deps */
 
-  const currentRumorText = currentRumorId ? getRumorTextById(currentRumorId) : ''
+  const currentRumorText =
+    rumorsQueue.length > 0 ? rumorsQueue[rumorsQueue.length - 1] : null
   const [advice, setAdvice] = useState('')
   const navigate = useNavigate()
 


### PR DESCRIPTION
## Summary
- expand rumors dataset with 10 rumors and conditions
- extend `rumorSelector` with `pickRandomRumor` helper
- update `TurnScreen` to auto-queue and display latest rumor

## Testing
- `npm run lint`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68514a17810c8328bbc65ecdc5af33e9