### PR TITLE
Standardize visual tags

### DIFF
--- a/src/data/plot_phases.json
+++ b/src/data/plot_phases.json
@@ -6,7 +6,9 @@
     "title": "Echoes of the War",
     "summary": "Even after peace was declared, some wounds refuse to heal.",
     "mood": "uncertain",
-    "visual": "village_ruins_calm_mist",
+    "visual": {
+      "tag_ia": "village_ruins_calm_mist"
+    },
     "tags": ["reconstruction", "recovery"],
     "forcedAdvanceAfter": 2
   },
@@ -17,7 +19,9 @@
     "title": "The Tax Revolt",
     "summary": "A noble-led rebellion erupts in response to sweeping reforms.",
     "mood": "tense",
-    "visual": "angry_nobles_castle_courtyard",
+    "visual": {
+      "tag_ia": "angry_nobles_castle_courtyard"
+    },
     "tags": ["resistance", "law"],
     "forcedAdvanceAfter": 3
   }

--- a/src/data/plots.json
+++ b/src/data/plots.json
@@ -96,7 +96,7 @@
     ],
     "level": "village",
     "visual": {
-      "tag_ia": "plot illustration for plot_border_flames"
+      "tag_ia": "gloomy war banners flapping at contested border"
     },
     "personajes_recomendados": {
       "facciones": [
@@ -171,7 +171,7 @@
       ]
     },
     "visual": {
-      "tag_ia": "plot illustration for betrayal_in_the_dunes"
+      "tag_ia": "gloomy desert ambush under shifting dunes"
     },
     "personajes_recomendados": {
       "facciones": [
@@ -238,7 +238,7 @@
       ]
     },
     "visual": {
-      "tag_ia": "plot illustration for the_forgotten_oath"
+      "tag_ia": "balanced loyalty ceremony under ancient stone"
     },
     "personajes_recomendados": {
       "facciones": [

--- a/src/data/reusable_scenes.json
+++ b/src/data/reusable_scenes.json
@@ -6,7 +6,9 @@
     "tags": ["ritual", "mourning"],
     "level": "royal_court",
     "tone": "dark",
-    "visual": "chapel_candles_ashes",
+    "visual": {
+      "tag_ia": "chapel_candles_ashes"
+    },
     "linked_plot_tags": ["legacy", "loss"],
     "conditions": {
       "prestige_below": 40,
@@ -20,7 +22,9 @@
     "tags": ["rumor", "tension"],
     "level": "village",
     "tone": "neutral",
-    "visual": "marketplace_shadows_listeners",
+    "visual": {
+      "tag_ia": "marketplace_shadows_listeners"
+    },
     "linked_plot_tags": ["intrigue", "deception"],
     "conditions": {
       "trust_below": 60


### PR DESCRIPTION
## Summary
- normalize `visual` fields in plot phases and reusable scenes
- improve plot visuals with short prompts

## Testing
- `npm run validate`

------
https://chatgpt.com/codex/tasks/task_e_6851578036a083289ce9289a79594c79