### PR TITLE
Add structured prompt support

### DIFF
--- a/src/data/prompts.json
+++ b/src/data/prompts.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "scene_intro_turn",
+    "type": "scene",
+    "context": "start_of_turn",
+    "requiredVariables": ["king", "plot", "kingdom", "playerReputation", "currentEmotion"],
+    "instructions": "You are the narrative engine of a game called El Consejero. Your job is to generate the initial scene that opens a turn, based on the player's current situation. The scene should set the tone, include subtle references to the emotional state of the court, and be symbolic or dramatic. It should never offer direct choices. The scene must be immersive, short (2–3 sentences), and written in the tone suggested by the plot. Do not use lists or markdown. Never repeat previous scenes.",
+    "outputExample": "The torches flicker unevenly as the King walks in silence. Outside, whispers of rebellion seep through the frost-covered windows.",
+    "visual_tags": ["symbolic", "introspective", "court_tension"]
+  }
+]

--- a/src/lib/kingdomSelector.ts
+++ b/src/lib/kingdomSelector.ts
@@ -2,7 +2,7 @@ import kingdoms from '../data/kingdoms.json'
 import type { Plot } from '../state/gameState'
 import type { Kingdom } from '../types'
 
-export function findMatchingKingdom(plot: Plot, _level: string): Kingdom | null {
+export function findMatchingKingdom(plot: Plot): Kingdom | null {
   let bestMatch: Kingdom | null = null
   let maxScore = 0
 

--- a/src/lib/narrative.ts
+++ b/src/lib/narrative.ts
@@ -1,4 +1,5 @@
 import { callAssistant } from './openai'
+import { getPromptByContext } from './promptSelector'
 
 import scenesData from '../data/reusable_scenes.json'
 import type { Plot, GameState } from '../state/gameState'
@@ -10,12 +11,12 @@ export interface ReusableScene {
   tags: string[]
   level: Plot['level']
   tone: string
-  visual: string
+  visual: { tag_ia: string }
   linked_plot_tags?: string[]
   conditions?: Record<string, unknown>
 }
 
-const scenes = scenesData as ReusableScene[]
+const scenes = scenesData as unknown as ReusableScene[]
 
 function conditionsMet(scene: ReusableScene, gameState: GameState): boolean {
   if (!scene.conditions) return true
@@ -91,15 +92,75 @@ export async function generateInitialPlot(): Promise<Plot | null> {
   }
 }
 
+export async function generateNarrativeScene(
+  gameState: GameState,
+  context = 'start_of_turn',
+): Promise<TurnContext> {
+  const template = getPromptByContext(context)
+  const fallback: TurnContext = {
+    sceneDescription:
+      'The court murmurs restlessly while shadows gather in the corners of the hall.',
+    sceneVisual: null,
+  }
+
+  if (!template) return fallback
+
+  const variables: Record<string, unknown> = {}
+  for (const v of template.requiredVariables) {
+    switch (v) {
+      case 'king':
+        variables.king = gameState.currentKing
+        break
+      case 'plot':
+        variables.plot = gameState.mainPlot
+        break
+      case 'kingdom':
+        variables.kingdom = gameState.kingdom
+        break
+      case 'playerReputation':
+        variables.playerReputation = {
+          prestige: gameState.prestige,
+          trust: gameState.trust,
+        }
+        break
+      case 'currentEmotion':
+        variables.currentEmotion = gameState.currentEmotion
+        break
+      default:
+        break
+    }
+  }
+
+  const prompt = `${template.instructions}\n\n${JSON.stringify(variables)}`
+
+  try {
+    const result = await callAssistant('asst_xBvJOGRlyLWAJlQeWWTLFw8q', prompt)
+    return {
+      sceneDescription: result || template.outputExample,
+      sceneVisual: null,
+    }
+  } catch (error) {
+    console.error('Failed to generate narrative scene', error)
+    return { ...fallback, sceneDescription: template.outputExample }
+  }
+}
+
 export interface TurnContext {
   sceneDescription: string
   sceneVisual: string | null
 }
 
-export function generateTurnContent(
+export async function generateTurnContent(
   plot: Plot,
   gameState: GameState,
-): TurnContext {
+): Promise<TurnContext> {
+  try {
+    const gptScene = await generateNarrativeScene(gameState, 'start_of_turn')
+    if (gptScene.sceneDescription) return gptScene
+  } catch {
+    // ignore and fall back to local scenes
+  }
+
   const possibleScenes = getEligibleScenes(plot, gameState)
   const scene = possibleScenes.length > 0
     ? possibleScenes[Math.floor(Math.random() * possibleScenes.length)]
@@ -107,6 +168,6 @@ export function generateTurnContent(
   const fallback = 'The court murmurs restlessly while shadows gather in the corners of the hall.'
   return {
     sceneDescription: scene ? scene.description : fallback,
-    sceneVisual: scene ? scene.visual : null,
+    sceneVisual: scene ? scene.visual.tag_ia : null,
   }
 }

--- a/src/lib/plotPhases.ts
+++ b/src/lib/plotPhases.ts
@@ -7,12 +7,12 @@ export interface PlotPhase {
   title: string
   summary: string
   mood: string
-  visual: string
+  visual: { tag_ia: string }
   tags: string[]
   forcedAdvanceAfter: number
 }
 
-const plotPhases = plotPhasesData as PlotPhase[]
+const plotPhases = plotPhasesData as unknown as PlotPhase[]
 
 export function getPhasesForPlot(plotId: string): PlotPhase[] {
   return plotPhases.filter((phase) => phase.plotId === plotId)

--- a/src/lib/promptSelector.ts
+++ b/src/lib/promptSelector.ts
@@ -1,0 +1,6 @@
+import type { PromptTemplate } from '../types'
+import prompts from '../data/prompts.json'
+
+export function getPromptByContext(context: string): PromptTemplate | null {
+  return (prompts as PromptTemplate[]).find((p) => p.context === context) || null
+}

--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -25,7 +25,7 @@ export default function PresentationScreen() {
     const init = async () => {
       try {
         if (mainPlot) {
-          const kingdomMatch = findMatchingKingdom(mainPlot, mainPlot.level)
+          const kingdomMatch = findMatchingKingdom(mainPlot)
           if (kingdomMatch) {
             setSelectedKingdom(kingdomMatch)
             setKingdom(kingdomMatch.name)
@@ -45,7 +45,7 @@ export default function PresentationScreen() {
           console.log('Generated plot:', plot)
           if (plot) {
             setMainPlot(plot)
-            const kingdomMatch = findMatchingKingdom(plot, plot.level)
+            const kingdomMatch = findMatchingKingdom(plot)
             if (kingdomMatch) {
               setSelectedKingdom(kingdomMatch)
               setKingdom(kingdomMatch.name)

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,3 +66,13 @@ export interface Kingdom {
   description?: string
 }
 
+
+export interface PromptTemplate {
+  id: string
+  type: 'scene' | 'event' | 'reaction' | 'twist'
+  context: string
+  requiredVariables: string[]
+  instructions: string
+  outputExample: string
+  visual_tags: string[]
+}


### PR DESCRIPTION
## Summary
- store GPT prompt templates under `src/data/prompts.json`
- define `PromptTemplate` interface
- add prompt lookup helper
- integrate prompt selection and GPT call in narrative logic
- update types for scenes and plot phases
- clean up kingdom selector API

## Testing
- `npm run lint`
- `npm run validate`
- `npm run validate:rumors` *(fails: rumor data invalid)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68515b79652483288797d183fb141621