### PR TITLE
Add narrative ending system

### DIFF
--- a/src/data/finals.json
+++ b/src/data/finals.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "final_trust_peace",
+    "title": "Harmony through Trust",
+    "description": "Thanks to your measured words and wisdom, the King and the people embraced peace.",
+    "condition": {
+      "trust_min": 80,
+      "war": false
+    },
+    "achievement_id": "golden_counselor",
+    "card_id": "card_peace",
+    "visual": {
+      "tag_ia": "golden throne room with peaceful faces, sunlight through stained glass",
+      "icon": "\ud83c\udf3f"
+    }
+  },
+  {
+    "id": "final_chaos_war",
+    "title": "Chaos of Betrayal",
+    "description": "Distrust and bloodshed consumed the realm after your ill-timed counsels.",
+    "condition": {
+      "trust_max": 30,
+      "war": true
+    },
+    "achievement_id": "dark_advisor",
+    "card_id": "card_war",
+    "visual": {
+      "tag_ia": "burning battlements under a crimson sky, despairing faces",
+      "icon": "\u2694\ufe0f"
+    }
+  }
+]

--- a/src/lib/finalSelector.ts
+++ b/src/lib/finalSelector.ts
@@ -1,0 +1,42 @@
+import finalsData from '../data/finals.json'
+import type { GameState } from '../state/gameState'
+
+export interface Final {
+  id: string
+  title: string
+  description: string
+  condition: Record<string, unknown>
+  achievement_id?: string
+  card_id?: string
+  visual: { tag_ia: string; icon: string }
+}
+
+const finals = finalsData as Final[]
+
+function matches(final: Final, state: GameState): boolean {
+  const cond = final.condition || {}
+  const s = state as unknown as Record<string, unknown>
+  for (const [key, value] of Object.entries(cond)) {
+    if (key.endsWith('_min')) {
+      const prop = key.replace(/_min$/, '')
+      if (typeof s[prop] !== 'number' || (s[prop] as number) < (value as number)) return false
+    } else if (key.endsWith('_max')) {
+      const prop = key.replace(/_max$/, '')
+      if (typeof s[prop] !== 'number' || (s[prop] as number) > (value as number)) return false
+    } else {
+      if (s[key] !== value) return false
+    }
+  }
+  return true
+}
+
+function specificity(final: Final): number {
+  return Object.keys(final.condition || {}).length
+}
+
+export function selectFinal(state: GameState): Final {
+  const eligible = finals.filter(f => matches(f, state))
+  if (eligible.length === 0) return finals[0]
+  eligible.sort((a, b) => specificity(b) - specificity(a))
+  return eligible[0]
+}

--- a/src/screens/logic/FinalScreen.tsx
+++ b/src/screens/logic/FinalScreen.tsx
@@ -1,15 +1,41 @@
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import ViewFinalScreen from '../view/ViewFinalScreen'
+import { selectFinal } from '../../lib/finalSelector'
+import type { Final } from '../../lib/finalSelector'
 
 export default function FinalScreen() {
   const navigate = useNavigate()
-  const { resetState } = useGameState()
+  const gameState = useGameState()
+  const { resetState } = gameState
+  const [final, setFinal] = useState<Final | null>(null)
+
+  useEffect(() => {
+    const result = selectFinal(useGameState.getState())
+    setFinal(result)
+
+    const stored = localStorage.getItem('player_profile')
+    const profile = stored ? JSON.parse(stored) : {}
+    profile.finals = Array.isArray(profile.finals) ? profile.finals : []
+    profile.finals.push(result.id)
+    if (result.achievement_id) {
+      profile.achievements = Array.isArray(profile.achievements)
+        ? profile.achievements
+        : []
+      profile.achievements.push(result.achievement_id)
+    }
+    if (result.card_id) {
+      profile.cards = Array.isArray(profile.cards) ? profile.cards : []
+      profile.cards.push(result.card_id)
+    }
+    localStorage.setItem('player_profile', JSON.stringify(profile))
+  }, [])
 
   const handleReset = () => {
     resetState()
     navigate('/')
   }
 
-  return <ViewFinalScreen onReset={handleReset} />
+  return <ViewFinalScreen final={final} onReset={handleReset} />
 }

--- a/src/screens/view/ViewFinalScreen.tsx
+++ b/src/screens/view/ViewFinalScreen.tsx
@@ -1,11 +1,28 @@
+import type { Final } from '../../lib/finalSelector'
+
 interface ViewFinalScreenProps {
+  final: Final | null
   onReset: () => void
 }
 
-export default function ViewFinalScreen({ onReset }: ViewFinalScreenProps) {
+export default function ViewFinalScreen({ final, onReset }: ViewFinalScreenProps) {
   return (
     <div>
-      <p>Your service has ended. The future of Eldoria is uncertain.</p>
+      {final ? (
+        <div>
+          <h2>
+            {final.visual.icon} {final.title}
+          </h2>
+          <p>{final.description}</p>
+          <p>Image tag: {final.visual.tag_ia}</p>
+          {final.achievement_id && (
+            <p>Achievement unlocked: {final.achievement_id}</p>
+          )}
+          {final.card_id && <p>Card unlocked: {final.card_id}</p>}
+        </div>
+      ) : (
+        <p>Loading ending...</p>
+      )}
       <button onClick={onReset}>Play Again</button>
     </div>
   )


### PR DESCRIPTION
## Summary
- add example final outcomes in `finals.json`
- implement `selectFinal` logic to choose an ending
- display final results and persist them on final screen

## Testing
- `npm run lint`
- `npm run build`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68516b62ed0483288ab29681f7d1e906