### PR TITLE
Add minimal turn loop

### DIFF
--- a/src/screens/logic/ReactionScreen.tsx
+++ b/src/screens/logic/ReactionScreen.tsx
@@ -1,18 +1,20 @@
-import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import ViewReactionScreen from '../view/ViewReactionScreen'
 
 export default function ReactionScreen() {
-  const { kingName, playerAdvice, kingReaction, activeEvents, setKingReaction } = useGameState()
+  const {
+    kingName,
+    playerAdvice,
+    kingReaction,
+    currentTurn,
+    setCurrentTurn,
+  } = useGameState()
   const navigate = useNavigate()
 
-  useEffect(() => {
-    setKingReaction('The King nods solemnly, but his gaze is stern.')
-  }, [setKingReaction])
-
-  const handleEnd = () => {
-    navigate('/final')
+  const handleContinue = () => {
+    setCurrentTurn(currentTurn + 1)
+    navigate('/turn')
   }
 
   return (
@@ -20,8 +22,7 @@ export default function ReactionScreen() {
       kingName={kingName}
       playerAdvice={playerAdvice}
       kingReaction={kingReaction}
-      activeEvent={activeEvents[0]}
-      onEnd={handleEnd}
+      onContinue={handleContinue}
     />
   )
 }

--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -2,23 +2,25 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import { checkAndTriggerMutations } from '../../lib/mutationLogic'
-import { getAvailableEvents } from '../../lib/eventSelector'
+import { getAvailableEvents, type Event } from '../../lib/eventSelector'
 import ViewTurnScreen from '../view/ViewTurnScreen'
 import { getRumorForCurrentState } from '../../lib/rumorSelector'
-import { getAvailableCharacters, CharacterEntry } from '../../lib/characterUtils'
+import { getAvailableCharacters, type CharacterEntry } from '../../lib/characterUtils'
 
 export default function TurnScreen() {
   const gameState = useGameState()
   const {
     setPlayerAdvice,
+    setKingReaction,
+    setTrust,
     mainPlot,
     currentTurn,
-    setCurrentTurn,
-    setActiveEvents,
+    trust,
     addRumors,
     rumorsQueue,
     level,
     currentEmotion,
+    currentKing,
   } = gameState
 
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -34,6 +36,7 @@ export default function TurnScreen() {
     rumorsQueue.length > 0 ? rumorsQueue[rumorsQueue.length - 1] : null
   const [advice, setAdvice] = useState('')
   const [availableChars, setAvailableChars] = useState<CharacterEntry[]>([])
+  const [currentEvent, setCurrentEvent] = useState<Event | null>(null)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -43,24 +46,36 @@ export default function TurnScreen() {
     }
   }, [mainPlot, currentEmotion, level])
 
+  useEffect(() => {
+    if (mainPlot) {
+      const events = getAvailableEvents(mainPlot, currentTurn)
+      setCurrentEvent(events.length > 0 ? events[0] : null)
+    }
+  }, [mainPlot, currentTurn])
+
   const handleSend = () => {
     setPlayerAdvice(advice)
-    const newTurn = currentTurn + 1
-    setCurrentTurn(newTurn)
+    setKingReaction('The King nods at your words and ponders.')
+    setTrust(trust + 5)
     if (mainPlot) {
-      const newEvents = getAvailableEvents(mainPlot, newTurn)
-      setActiveEvents(newEvents)
+      checkAndTriggerMutations(currentTurn, mainPlot, useGameState.getState())
     }
-    checkAndTriggerMutations(newTurn, mainPlot, useGameState.getState())
     navigate('/reaction')
   }
 
   return (
     <ViewTurnScreen
       rumor={currentRumorText}
+      event={currentEvent}
+      visualTag={currentEvent?.visual?.tag_ia || currentKing?.visual?.tag_ia || null}
       advice={advice}
       onAdviceChange={setAdvice}
       onSend={handleSend}
+      debugInfo={
+        import.meta.env.DEV
+          ? `turn:${currentTurn} trust:${trust} prestige:${gameState.prestige} war:${gameState.war}\nplot:${mainPlot?.id} king:${currentKing?.id}`
+          : undefined
+      }
       debugCharacters={import.meta.env.DEV ? availableChars : undefined}
     />
   )

--- a/src/screens/view/ViewReactionScreen.tsx
+++ b/src/screens/view/ViewReactionScreen.tsx
@@ -1,21 +1,23 @@
-import type { Event } from '../../lib/eventSelector'
-import EventCard from '../../components/EventCard'
-
 interface ViewReactionScreenProps {
   kingName: string
   playerAdvice: string
   kingReaction: string
-  activeEvent?: Event
-  onEnd: () => void
+  onContinue: () => void
 }
 
-export default function ViewReactionScreen({ kingName, playerAdvice, kingReaction, activeEvent, onEnd }: ViewReactionScreenProps) {
+export default function ViewReactionScreen({
+  kingName,
+  playerAdvice,
+  kingReaction,
+  onContinue,
+}: ViewReactionScreenProps) {
   return (
     <div>
-      <p>Your advice to King {kingName}: {playerAdvice}</p>
+      <p>
+        Your advice to King {kingName}: {playerAdvice}
+      </p>
       <p>{kingReaction}</p>
-      {activeEvent && <EventCard event={activeEvent} />}
-      <button onClick={onEnd}>End Game</button>
+      <button onClick={onContinue}>Continue to next turn</button>
     </div>
   )
 }

--- a/src/screens/view/ViewTurnScreen.tsx
+++ b/src/screens/view/ViewTurnScreen.tsx
@@ -1,8 +1,13 @@
+import type { Event } from '../../lib/eventSelector'
+
 interface ViewTurnScreenProps {
   rumor?: string | null
+  event?: Event | null
+  visualTag?: string | null
   advice: string
   onAdviceChange: (value: string) => void
   onSend: () => void
+  debugInfo?: string
   debugCharacters?: {
     id: string
     name: string
@@ -14,9 +19,12 @@ interface ViewTurnScreenProps {
 
 export default function ViewTurnScreen({
   rumor,
+  event,
+  visualTag,
   advice,
   onAdviceChange,
   onSend,
+  debugInfo,
   debugCharacters,
 }: ViewTurnScreenProps) {
   return (
@@ -26,14 +34,22 @@ export default function ViewTurnScreen({
           <p className="rumor-text">🕵️ Rumor: {rumor}</p>
         </div>
       )}
-      <p>The villagers have gathered in the square with torches.</p>
-      <p>Should we intervene or let them speak freely?</p>
+      {event && (
+        <div>
+          <h3>{event.title}</h3>
+          <p>{event.description}</p>
+        </div>
+      )}
+      {visualTag && <div style={{ opacity: 0.7 }}>Image tag: {visualTag}</div>}
       <textarea
         value={advice}
         onChange={(e) => onAdviceChange(e.target.value)}
         placeholder="Your advice"
       />
       <button onClick={onSend}>Send Advice</button>
+      {debugInfo && (
+        <pre style={{ fontSize: '0.8rem' }}>{debugInfo}</pre>
+      )}
       {debugCharacters && debugCharacters.length > 0 && (
         <details style={{ marginTop: '1rem' }}>
           <summary>Debug Characters</summary>


### PR DESCRIPTION
## Summary
- fetch first available event and show it in Turn screen
- simulate a reaction and update trust when sending advice
- show saved reaction and continue to next turn from Reaction screen
- display rumor, image tag, and debug info during turns

## Testing
- `npm run lint`
- `npm run validate`
- `npm run validate:rumors`


------
https://chatgpt.com/codex/tasks/task_e_6851758ebc208328bee80a10aa2a3af9