### PR TITLE
Standardize rumor utilities to english schema

### DIFF
--- a/src/lib/rumorSelector.ts
+++ b/src/lib/rumorSelector.ts
@@ -3,50 +3,44 @@ import { useGameState } from '../state/gameState'
 
 interface Rumor {
   id: string
-  texto: string
-  condiciones?: {
-    prestigio_min?: number
-    prestigio_max?: number
-    confianza_min?: number
-    confianza_max?: number
-    guerra?: boolean
-    turno_min?: number
-    turno_max?: number
+  text: string
+  conditions?: {
+    prestige_min?: number
+    prestige_max?: number
+    trust_min?: number
+    trust_max?: number
+    war?: boolean
+    turn_min?: number
+    turn_max?: number
   }
-  peso?: number
-  tipo?: string
+  weight?: number
+  type?: string
 }
 
 export function getRumorForCurrentState() {
-  // Map actual state properties to Spanish variable names
-  const {
-    trust: confianza,
-    prestige: prestigio,
-    war: guerra,
-    currentTurn,
-  } = useGameState.getState()
+  const { trust, prestige, war, currentTurn } = useGameState.getState()
 
-  const candidatos = (rumors as unknown as Rumor[]).filter(rumor => {
-    const c = rumor.condiciones || {}
-    if (c.prestigio_min !== undefined && prestigio < c.prestigio_min) return false
-    if (c.prestigio_max !== undefined && prestigio > c.prestigio_max) return false
-    if (c.confianza_min !== undefined && confianza < c.confianza_min) return false
-    if (c.confianza_max !== undefined && confianza > c.confianza_max) return false
-    if (c.guerra !== undefined && guerra !== c.guerra) return false
-    if (c.turno_min !== undefined && currentTurn < c.turno_min) return false
-    if (c.turno_max !== undefined && currentTurn > c.turno_max) return false
+  const candidates = (rumors as unknown as Rumor[]).filter((rumor) => {
+    const c = rumor.conditions || {}
+    if (c.prestige_min !== undefined && prestige < c.prestige_min) return false
+    if (c.prestige_max !== undefined && prestige > c.prestige_max) return false
+    if (c.trust_min !== undefined && trust < c.trust_min) return false
+    if (c.trust_max !== undefined && trust > c.trust_max) return false
+    if (c.war !== undefined && war !== c.war) return false
+    if (c.turn_min !== undefined && currentTurn < c.turn_min) return false
+    if (c.turn_max !== undefined && currentTurn > c.turn_max) return false
     return true
   })
 
-  if (candidatos.length === 0) return null
+  if (candidates.length === 0) return null
 
-  const totalPeso = candidatos.reduce((acc, r) => acc + (r.peso || 1), 0)
-  const random = Math.random() * totalPeso
-  let acumulado = 0
-  for (const rumor of candidatos) {
-    acumulado += rumor.peso || 1
-    if (random <= acumulado) return rumor.texto
+  const totalWeight = candidates.reduce((acc, r) => acc + (r.weight || 1), 0)
+  const random = Math.random() * totalWeight
+  let accumulated = 0
+  for (const rumor of candidates) {
+    accumulated += rumor.weight || 1
+    if (random <= accumulated) return rumor.text
   }
 
-  return candidatos[0].texto
+  return candidates[0].text
 }

--- a/src/lib/rumorUtils.ts
+++ b/src/lib/rumorUtils.ts
@@ -3,39 +3,35 @@ import { useGameState } from '../state/gameState'
 
 export interface Rumor {
   id: string
-  texto: string
-  condiciones?: {
-    prestigio_min?: number
-    prestigio_max?: number
-    confianza_min?: number
-    confianza_max?: number
-    guerra?: boolean
+  text: string
+  conditions?: {
+    prestige_min?: number
+    prestige_max?: number
+    trust_min?: number
+    trust_max?: number
+    war?: boolean
   }
-  peso?: number
-  tipo?: string
+  weight?: number
+  type?: string
 }
 
 const rumors = rumorsData as unknown as Rumor[]
 
 export function getRumorTextById(id: string): string {
-  const found = rumors.find(r => r.id === id)
-  return found?.texto || '[Missing rumor text]'
+  const found = rumors.find((r) => r.id === id)
+  return found?.text || '[Missing rumor text]'
 }
 
 export function getValidRumors(): Rumor[] {
-  const {
-    prestige: prestigio,
-    trust: confianza,
-    war: guerra,
-  } = useGameState.getState()
-  return rumors.filter(rumor => {
-    const c = rumor.condiciones
+  const { prestige, trust, war } = useGameState.getState()
+  return rumors.filter((rumor) => {
+    const c = rumor.conditions
     if (!c) return true
-    if (c.prestigio_min !== undefined && prestigio < c.prestigio_min) return false
-    if (c.prestigio_max !== undefined && prestigio > c.prestigio_max) return false
-    if (c.confianza_min !== undefined && confianza < c.confianza_min) return false
-    if (c.confianza_max !== undefined && confianza > c.confianza_max) return false
-    if (c.guerra !== undefined && guerra !== c.guerra) return false
+    if (c.prestige_min !== undefined && prestige < c.prestige_min) return false
+    if (c.prestige_max !== undefined && prestige > c.prestige_max) return false
+    if (c.trust_min !== undefined && trust < c.trust_min) return false
+    if (c.trust_max !== undefined && trust > c.trust_max) return false
+    if (c.war !== undefined && war !== c.war) return false
     return true
   })
 }
@@ -44,5 +40,5 @@ export function pickRandomRumor(): string {
   const validRumors = getValidRumors()
   if (validRumors.length === 0) return 'The realm is silent...'
   const randomIndex = Math.floor(Math.random() * validRumors.length)
-  return validRumors[randomIndex].texto
+  return validRumors[randomIndex].text
 }


### PR DESCRIPTION
## Summary
- update `rumorSelector` and `rumorUtils` to read english property names
- adjust interfaces to use `text`, `conditions`, and `weight`

## Testing
- `npm run lint`
- `npm run validate:rumors`


------
https://chatgpt.com/codex/tasks/task_e_68517fda0dc88328aebd70cf044e3b92