### PR TITLE
Implement turn flow logic

### DIFF
--- a/src/screens/logic/TurnScreen.tsx
+++ b/src/screens/logic/TurnScreen.tsx
@@ -5,10 +5,14 @@ import { checkAndTriggerMutations } from '../../lib/mutationLogic'
 import { getAvailableEvents, type Event } from '../../lib/eventSelector'
 import ViewTurnScreen from '../view/ViewTurnScreen'
 import { getRumorForCurrentState } from '../../lib/rumorSelector'
-import { getAvailableCharacters, type CharacterEntry } from '../../lib/characterUtils'
+import {
+  getAvailableCharacters,
+  type CharacterEntry,
+} from '../../lib/characterUtils'
 import Loader from '../../components/Loader'
 import { callAssistant as rawCall } from '../../lib/openai'
 import { getPromptTemplate } from '../../lib/openai/promptTemplates'
+import { runPromptWithValidation } from '../../lib/openai/promptExecutor'
 
 export default function TurnScreen() {
   const gameState = useGameState()
@@ -16,6 +20,7 @@ export default function TurnScreen() {
     setPlayerAdvice,
     setKingReaction,
     setTrust,
+    setActiveEvents,
     mainPlot,
     currentTurn,
     trust,
@@ -26,35 +31,56 @@ export default function TurnScreen() {
     currentKing,
   } = gameState
 
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    const rumor = getRumorForCurrentState()
-    if (rumor && !rumorsQueue.includes(rumor)) {
-      addRumors([rumor])
-    }
-  }, [])
-  /* eslint-enable react-hooks/exhaustive-deps */
 
   const currentRumorText =
     rumorsQueue.length > 0 ? rumorsQueue[rumorsQueue.length - 1] : null
   const [advice, setAdvice] = useState('')
   const [availableChars, setAvailableChars] = useState<CharacterEntry[]>([])
-  const [currentEvent, setCurrentEvent] = useState<Event | null>(null)
+  const [currentEventLocal, setCurrentEventLocal] = useState<Event | null>(null)
+  const [dilemma, setDilemma] = useState('')
+  const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const navigate = useNavigate()
 
   useEffect(() => {
-    if (mainPlot) {
-      const chars = getAvailableCharacters(mainPlot, currentEmotion, level)
-      setAvailableChars(chars)
+    if (!mainPlot) {
+      navigate('/presentation')
+      return
     }
-  }, [mainPlot, currentEmotion, level])
 
-  useEffect(() => {
-    if (mainPlot) {
-      const events = getAvailableEvents(mainPlot, currentTurn)
-      setCurrentEvent(events.length > 0 ? events[0] : null)
+    const init = async () => {
+      setLoading(true)
+      try {
+        checkAndTriggerMutations(
+          currentTurn,
+          mainPlot,
+          useGameState.getState(),
+        )
+
+        const rumor = getRumorForCurrentState()
+        if (rumor && !rumorsQueue.includes(rumor)) {
+          addRumors([rumor])
+        }
+
+        const chars = getAvailableCharacters(mainPlot, currentEmotion, level)
+        setAvailableChars(chars)
+
+        const events = getAvailableEvents(mainPlot, currentTurn)
+        setActiveEvents(events)
+        const first = events.length > 0 ? events[0] : null
+        setCurrentEventLocal(first)
+
+        const turnText = await runPromptWithValidation('turn')
+        setDilemma(turnText)
+      } catch (err) {
+        console.error('Error preparing turn', err)
+        setError('Failed to generate dilemma')
+      } finally {
+        setLoading(false)
+      }
     }
+    init()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mainPlot, currentTurn])
 
   const handleSend = async () => {
@@ -80,9 +106,6 @@ export default function TurnScreen() {
       setKingReaction('The King nods at your words and ponders.')
     } finally {
       setTrust(trust + 5)
-      if (mainPlot) {
-        checkAndTriggerMutations(currentTurn, mainPlot, useGameState.getState())
-      }
       setLoading(false)
       navigate('/reaction')
     }
@@ -93,8 +116,11 @@ export default function TurnScreen() {
   ) : (
     <ViewTurnScreen
       rumor={currentRumorText}
-      event={currentEvent}
-      visualTag={currentEvent?.visual?.tag_ia || currentKing?.visual?.tag_ia || null}
+      event={currentEventLocal}
+      dilemma={dilemma}
+      visualTag={
+        currentEventLocal?.visual?.tag_ia || currentKing?.visual?.tag_ia || null
+      }
       advice={advice}
       onAdviceChange={setAdvice}
       onSend={handleSend}
@@ -104,6 +130,7 @@ export default function TurnScreen() {
           : undefined
       }
       debugCharacters={import.meta.env.DEV ? availableChars : undefined}
+      error={error || undefined}
     />
   )
 }

--- a/src/screens/view/ViewTurnScreen.tsx
+++ b/src/screens/view/ViewTurnScreen.tsx
@@ -3,6 +3,7 @@ import type { Event } from '../../lib/eventSelector'
 interface ViewTurnScreenProps {
   rumor?: string | null
   event?: Event | null
+  dilemma?: string | null
   visualTag?: string | null
   advice: string
   onAdviceChange: (value: string) => void
@@ -15,17 +16,20 @@ interface ViewTurnScreenProps {
     tags: string[]
     visual?: { tag_ia: string }
   }[]
+  error?: string
 }
 
 export default function ViewTurnScreen({
   rumor,
   event,
+  dilemma,
   visualTag,
   advice,
   onAdviceChange,
   onSend,
   debugInfo,
   debugCharacters,
+  error,
 }: ViewTurnScreenProps) {
   return (
     <div>
@@ -39,6 +43,14 @@ export default function ViewTurnScreen({
           <h3>{event.title}</h3>
           <p>{event.description}</p>
         </div>
+      )}
+      {dilemma && (
+        <div style={{ marginBottom: '0.5rem' }}>
+          <p>{dilemma}</p>
+        </div>
+      )}
+      {error && (
+        <p style={{ color: 'red' }}>{error}</p>
       )}
       {visualTag && <div style={{ opacity: 0.7 }}>Image tag: {visualTag}</div>}
       <textarea


### PR DESCRIPTION
## Summary
- run turn logic at start of Turn screen
- generate events and rumor and run GPT prompt for dilemma
- show dilemma and errors in `ViewTurnScreen`
- pass data from logic layer to view

## Testing
- `npm run lint`
- `npm run build` *(fails: type errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6851818e1d908328a438305fc236df86