### PR TITLE
Fix PresentationScreen initialization

### DIFF
--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import { generateInitialPlot, initialPlotPrompt } from '../../lib/narrative'
@@ -22,8 +22,12 @@ export default function PresentationScreen() {
   const [debugText, setDebugText] = useState('')
   const [selectedKingdom, setSelectedKingdom] = useState<Kingdom | null>(null)
   const [loading, setLoading] = useState(false)
+  const hasInitialized = useRef(false)
 
   useEffect(() => {
+    if (hasInitialized.current || mainPlot) return
+    hasInitialized.current = true
+
     const init = async () => {
       setLoading(true)
       try {


### PR DESCRIPTION
## Summary
- ensure `init` in `PresentationScreen` only runs once even when `StrictMode` mounts twice

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68518d94bb5c8328b17f83f5b0d7f912