### PR TITLE
Fix duplicate initial plot generation

### DIFF
--- a/src/screens/logic/PresentationScreen.tsx
+++ b/src/screens/logic/PresentationScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../../state/gameState'
 import { generateInitialPlot, initialPlotPrompt } from '../../lib/narrative'
@@ -7,6 +7,9 @@ import { findMatchingKingdom } from '../../lib/kingdomSelector'
 import type { Kingdom } from '../../types'
 import ViewPresentationScreen from '../view/ViewPresentationScreen'
 import Loader from '../../components/Loader'
+
+// Persist initialization status across StrictMode remounts
+let plotInitialized = false
 
 export default function PresentationScreen() {
   const {
@@ -22,11 +25,10 @@ export default function PresentationScreen() {
   const [debugText, setDebugText] = useState('')
   const [selectedKingdom, setSelectedKingdom] = useState<Kingdom | null>(null)
   const [loading, setLoading] = useState(false)
-  const hasInitialized = useRef(false)
 
   useEffect(() => {
-    if (hasInitialized.current || mainPlot) return
-    hasInitialized.current = true
+    if (plotInitialized || mainPlot) return
+    plotInitialized = true
 
     const init = async () => {
       setLoading(true)


### PR DESCRIPTION
## Summary
- prevent duplicate calls to OpenAI when running under React StrictMode

## Testing
- `npm run lint`
- `npm run validate`
- `npm run validate:rumors`


------
https://chatgpt.com/codex/tasks/task_e_68518f451f3883288787da8079bdd5da